### PR TITLE
Optimize NetToggle Root/Shizuku handling and QS tile performance

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,7 @@ android {
         applicationId = "com.dhangofa.networktoggle"
         minSdk = 24
         targetSdk = 36
-        versionCode = 2
+        versionCode = (project.findProperty("versionCode") as String?)?.toIntOrNull() ?: 2
         versionName = "1.0"
     }
     // Suggested by IzzyOnDroid

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,2 +1,6 @@
 # Keep the Quick Settings TileService intact during R8/Proguard minification
 -keep class com.dhangofa.networktoggle.NetworkTileService { *; }
+-keep class rikka.shizuku.** { *; }
+-keep class moe.shizuku.** { *; }
+-dontwarn rikka.shizuku.**
+-dontwarn moe.shizuku.**

--- a/app/src/main/java/com/dhangofa/networktoggle/MainActivity.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/MainActivity.java
@@ -34,40 +34,51 @@ public class MainActivity extends Activity {
     private RadioButton radioShizuku;
     private TextView statusText;
     private SharedPreferences prefs;
-
+	
+	private volatile boolean activityDestroyed = false;
+	private Thread rootCheckThread;
+	private Process rootCheckProcess;
+	
     // 1. First check Shizuku mode selected then wait for Shizuku Binder to be injected, then check permissions
     private final Shizuku.OnBinderReceivedListener binderReceivedListener = () -> {
-		runOnUiThread(() -> {
-			if (prefs != null && prefs.getInt(EXEC_MODE_KEY, MODE_NONE) == MODE_SHIZUKU) {
-				checkShizukuPermission(false);
-			}
-		});
+	    runOnUiThread(() -> {
+	        if (!activityDestroyed
+	                && prefs != null
+	                && prefs.getInt(EXEC_MODE_KEY, MODE_NONE) == MODE_SHIZUKU) {
+	            checkShizukuPermission(false);
+	        }
+	    });
 	};
 
     // 2. Handle if Shizuku suddenly dies in the background
     private final Shizuku.OnBinderDeadListener binderDeadListener = () -> {
-		runOnUiThread(() -> {
-			if (prefs != null && prefs.getInt(EXEC_MODE_KEY, MODE_NONE) == MODE_SHIZUKU) {
-				statusText.setText("Shizuku is not running.");
-				statusText.setTextColor(0xFFFF5555);
-			}
-		});
+	    runOnUiThread(() -> {
+	        if (!activityDestroyed
+	                && prefs != null
+	                && prefs.getInt(EXEC_MODE_KEY, MODE_NONE) == MODE_SHIZUKU) {
+	            statusText.setText("Shizuku is not running.");
+	            statusText.setTextColor(0xFFFF5555);
+	        }
+	    });
 	};
 
 
     // 3. React instantly when the user taps "Allow" on the Shizuku Popup
     private final Shizuku.OnRequestPermissionResultListener permissionResultListener = (requestCode, grantResult) -> {
-        runOnUiThread(() -> {
-            if (prefs != null && prefs.getInt(EXEC_MODE_KEY, MODE_NONE) == MODE_SHIZUKU) {
-                checkShizukuPermission(false);
-            }
-        });
-    };
+	    runOnUiThread(() -> {
+	        if (!activityDestroyed
+	                && prefs != null
+	                && prefs.getInt(EXEC_MODE_KEY, MODE_NONE) == MODE_SHIZUKU) {
+	            checkShizukuPermission(false);
+	        }
+	    });
+	};
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+        activityDestroyed = false;
+		setContentView(R.layout.activity_main);
 
         prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         
@@ -106,48 +117,84 @@ public class MainActivity extends Activity {
         });
     }
 
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        // Prevent memory leaks by destroying the listeners when the app closes
-        Shizuku.removeBinderReceivedListener(binderReceivedListener);
-        Shizuku.removeBinderDeadListener(binderDeadListener);
-        Shizuku.removeRequestPermissionResultListener(permissionResultListener);
-    }
+   @Override
+	protected void onDestroy() {
+	    activityDestroyed = true;
+	
+	    // Prevent memory leaks by destroying Shizuku listeners when the app closes
+	    Shizuku.removeBinderReceivedListener(binderReceivedListener);
+	    Shizuku.removeBinderDeadListener(binderDeadListener);
+	    Shizuku.removeRequestPermissionResultListener(permissionResultListener);
+	
+	    // Stop any running root permission check process
+	    if (rootCheckProcess != null) {
+	        rootCheckProcess.destroy();
+	        rootCheckProcess = null;
+	    }
+	
+	    // Interrupt root check thread if it is still active
+	    if (rootCheckThread != null && rootCheckThread.isAlive()) {
+	        rootCheckThread.interrupt();
+	        rootCheckThread = null;
+	    }
+	
+	    super.onDestroy();
+	}
 
     private void checkRootPermission() {
-        statusText.setText("Checking root permission...");
-        statusText.setTextColor(0xFFFFB300);
-    
-        new Thread(() -> {
-            boolean granted = false;
-    
-            try {
-                Process process = Runtime.getRuntime().exec(new String[]{"su", "-c", "id"});
-                int exitCode = process.waitFor();
-                granted = exitCode == 0;
-            } catch (Exception ignored) {
-                granted = false;
-            }
-    
-            boolean finalGranted = granted;
-			runOnUiThread(() -> {
-				if (prefs == null || prefs.getInt(EXEC_MODE_KEY, MODE_NONE) != MODE_ROOT) {
-					return;
-				}
-
-				if (finalGranted) {
-					statusText.setText("Root mode active & authorized!");
-					statusText.setTextColor(0xFF1B873F);
-				} else {
-					statusText.setText("Root permission denied or unavailable.");
-					statusText.setTextColor(0xFFFF5555);
-				}
-			});
-        }).start();
-    }
+	    statusText.setText("Checking root permission...");
+	    statusText.setTextColor(0xFFFFB300);
+	
+	    rootCheckThread = new Thread(() -> {
+	        boolean granted = false;
+	        Process process = null;
+	
+	        try {
+	            process = Runtime.getRuntime().exec(new String[]{"su", "-c", "id"});
+	            rootCheckProcess = process;
+	
+	            int exitCode = process.waitFor();
+	            granted = exitCode == 0;
+	        } catch (Exception ignored) {
+	            granted = false;
+	        } finally {
+	            if (process != null) {
+	                process.destroy();
+	            }
+	
+	            if (rootCheckProcess == process) {
+	                rootCheckProcess = null;
+	            }
+	        }
+	
+	        boolean finalGranted = granted;
+	
+	        runOnUiThread(() -> {
+	            if (activityDestroyed) {
+	                return;
+	            }
+	
+	            if (prefs == null || prefs.getInt(EXEC_MODE_KEY, MODE_NONE) != MODE_ROOT) {
+	                return;
+	            }
+	
+	            if (finalGranted) {
+	                statusText.setText("Root mode active & authorized!");
+	                statusText.setTextColor(0xFF1B873F);
+	            } else {
+	                statusText.setText("Root permission denied or unavailable.");
+	                statusText.setTextColor(0xFFFF5555);
+	            }
+	        });
+	    });
+	
+	    rootCheckThread.start();
+	}
     
     private void checkShizukuPermission(boolean requestIfNeeded) {
+		if (activityDestroyed) {
+		    return;
+		}
 		try {
 			if (!Shizuku.pingBinder()) {
 				statusText.setText("Shizuku is not running.");

--- a/app/src/main/java/com/dhangofa/networktoggle/MainActivity.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/MainActivity.java
@@ -1,3 +1,13 @@
+/*
+Behavior:
+- Fresh install: no option selected.
+- Root selected: root permission checked.
+- Shizuku selected: Shizuku permission checked/requested only then.
+- Saved Root: root rechecked on open.
+- Saved Shizuku: status checked without auto-popup.
+- Shizuku callbacks update UI only when Shizuku mode is selected.
+*/
+
 package com.dhangofa.networktoggle;
 
 import android.app.Activity;
@@ -7,12 +17,17 @@ import android.os.Bundle;
 import android.widget.RadioButton;
 import android.widget.RadioGroup;
 import android.widget.TextView;
+
 import rikka.shizuku.Shizuku;
 
 public class MainActivity extends Activity {
 
     private static final String PREFS_NAME = "NetTogglePrefs";
     private static final String EXEC_MODE_KEY = "exec_mode";
+	
+    private static final int MODE_NONE = 0;
+    private static final int MODE_ROOT = 1;
+    private static final int MODE_SHIZUKU = 2;
 
     private RadioGroup radioGroup;
     private RadioButton radioRoot;
@@ -20,22 +35,33 @@ public class MainActivity extends Activity {
     private TextView statusText;
     private SharedPreferences prefs;
 
-    // 1. Wait for Shizuku Binder to be injected, then check permissions
+    // 1. First check Shizuku mode selected then wait for Shizuku Binder to be injected, then check permissions
     private final Shizuku.OnBinderReceivedListener binderReceivedListener = () -> {
-        runOnUiThread(this::checkShizukuPermission);
-    };
+		runOnUiThread(() -> {
+			if (prefs != null && prefs.getInt(EXEC_MODE_KEY, MODE_NONE) == MODE_SHIZUKU) {
+				checkShizukuPermission(false);
+			}
+		});
+	};
 
     // 2. Handle if Shizuku suddenly dies in the background
     private final Shizuku.OnBinderDeadListener binderDeadListener = () -> {
-        runOnUiThread(() -> {
-            statusText.setText("Shizuku is not running.");
-            statusText.setTextColor(0xFFFF5555); // Red
-        });
-    };
+		runOnUiThread(() -> {
+			if (prefs != null && prefs.getInt(EXEC_MODE_KEY, MODE_NONE) == MODE_SHIZUKU) {
+				statusText.setText("Shizuku is not running.");
+				statusText.setTextColor(0xFFFF5555);
+			}
+		});
+	};
+
 
     // 3. React instantly when the user taps "Allow" on the Shizuku Popup
     private final Shizuku.OnRequestPermissionResultListener permissionResultListener = (requestCode, grantResult) -> {
-        runOnUiThread(this::checkShizukuPermission);
+        runOnUiThread(() -> {
+            if (prefs != null && prefs.getInt(EXEC_MODE_KEY, MODE_NONE) == MODE_SHIZUKU) {
+                checkShizukuPermission(false);
+            }
+        });
     };
 
     @Override
@@ -55,22 +81,27 @@ public class MainActivity extends Activity {
         Shizuku.addBinderDeadListener(binderDeadListener);
         Shizuku.addRequestPermissionResultListener(permissionResultListener);
 
-        // Load saved mode (Default: Root = 1, Shizuku = 2)
-        int savedMode = prefs.getInt(EXEC_MODE_KEY, 1);
-        if (savedMode == 2) {
-            radioShizuku.setChecked(true);
-            checkShizukuPermission(); // Try immediately
-        } else {
+        // Load saved mode (Default =0, Root = 1, Shizuku = 2)
+        int savedMode = prefs.getInt(EXEC_MODE_KEY, MODE_NONE);
+        if (savedMode == MODE_ROOT) {
             radioRoot.setChecked(true);
+            checkRootPermission();
+        } else if (savedMode == MODE_SHIZUKU) {
+            radioShizuku.setChecked(true);
+            checkShizukuPermission(false);
+        } else {
+            radioGroup.clearCheck();
+            statusText.setText("Select Root or Shizuku mode.");
+            statusText.setTextColor(0xFFFFB300);
         }
 
         radioGroup.setOnCheckedChangeListener((group, checkedId) -> {
             if (checkedId == R.id.radioRoot) {
-                prefs.edit().putInt(EXEC_MODE_KEY, 1).apply();
-                statusText.setText("");
+                prefs.edit().putInt(EXEC_MODE_KEY, MODE_ROOT).apply();
+                checkRootPermission();
             } else if (checkedId == R.id.radioShizuku) {
-                prefs.edit().putInt(EXEC_MODE_KEY, 2).apply();
-                checkShizukuPermission();
+                prefs.edit().putInt(EXEC_MODE_KEY, MODE_SHIZUKU).apply();
+                checkShizukuPermission(true);
             }
         });
     }
@@ -84,20 +115,63 @@ public class MainActivity extends Activity {
         Shizuku.removeRequestPermissionResultListener(permissionResultListener);
     }
 
-    private void checkShizukuPermission() {
-        if (!Shizuku.pingBinder()) {
-            statusText.setText("Waiting for Shizuku...");
-            statusText.setTextColor(0xFFFF5555); // Red
-            return;
-        }
+    private void checkRootPermission() {
+        statusText.setText("Checking root permission...");
+        statusText.setTextColor(0xFFFFB300);
+    
+        new Thread(() -> {
+            boolean granted = false;
+    
+            try {
+                Process process = Runtime.getRuntime().exec(new String[]{"su", "-c", "id"});
+                int exitCode = process.waitFor();
+                granted = exitCode == 0;
+            } catch (Exception ignored) {
+                granted = false;
+            }
+    
+            boolean finalGranted = granted;
+			runOnUiThread(() -> {
+				if (prefs == null || prefs.getInt(EXEC_MODE_KEY, MODE_NONE) != MODE_ROOT) {
+					return;
+				}
 
-        if (Shizuku.checkSelfPermission() != PackageManager.PERMISSION_GRANTED) {
-            statusText.setText("Requesting Shizuku permission...");
-            statusText.setTextColor(0xFFFFB300); // Yellow
-            Shizuku.requestPermission(0); // This line triggers the Auto-Popup
-        } else {
-            statusText.setText("Shizuku mode active & authorized!");
-            statusText.setTextColor(0xFF1B873F); // Green
-        }
+				if (finalGranted) {
+					statusText.setText("Root mode active & authorized!");
+					statusText.setTextColor(0xFF1B873F);
+				} else {
+					statusText.setText("Root permission denied or unavailable.");
+					statusText.setTextColor(0xFFFF5555);
+				}
+			});
+        }).start();
     }
+    
+    private void checkShizukuPermission(boolean requestIfNeeded) {
+		try {
+			if (!Shizuku.pingBinder()) {
+				statusText.setText("Shizuku is not running.");
+				statusText.setTextColor(0xFFFF5555);
+				return;
+			}
+
+			if (Shizuku.checkSelfPermission() == PackageManager.PERMISSION_GRANTED) {
+				statusText.setText("Shizuku mode active & authorized!");
+				statusText.setTextColor(0xFF1B873F);
+				return;
+			}
+
+			statusText.setText("Shizuku permission not granted.");
+			statusText.setTextColor(0xFFFFB300);
+
+			if (requestIfNeeded) {
+				statusText.setText("Requesting Shizuku permission...");
+				statusText.setTextColor(0xFFFFB300);
+				Shizuku.requestPermission(0);
+			}
+		} catch (Exception e) {
+			statusText.setText("Shizuku check failed.");
+			statusText.setTextColor(0xFFFF5555);
+		}
+	}
 }

--- a/app/src/main/java/com/dhangofa/networktoggle/NetworkTileService.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/NetworkTileService.java
@@ -9,13 +9,17 @@ import android.graphics.Typeface;
 import android.graphics.drawable.Icon;
 import android.service.quicksettings.Tile;
 import android.service.quicksettings.TileService;
-import android.telephony.SubscriptionManager;
 import android.os.Handler;
 import android.os.Looper;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.lang.reflect.Method;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import rikka.shizuku.Shizuku;
 
 public class NetworkTileService extends TileService {
@@ -37,12 +41,21 @@ public class NetworkTileService extends TileService {
     private static final String BIN_4G_ONLY = "1000000000000"; // Legacy Id 11, bitmask 4096
     private static final String BIN_5G_ONLY = "10000000000000000000"; // Legacy Id 23, bitmask 524288
     private static final String BIN_PREF_5G = "11011111101111111111"; // Legacy Id 33, bitmask 916479
-    private static final String BIN_PREF_4G = "1001101001110000111"; // Legacy Id 9 , bitmask 316295
+    private static final String BIN_PREF_4G = "1001101001110000111"; // Legacy Id 9, bitmask 316295
+	
+	private static final int LEGACY_4G_ONLY = 11;
+	private static final int LEGACY_5G_ONLY = 23;
+	private static final int LEGACY_PREF_5G = 33;
+	private static final int LEGACY_PREF_4G = 9;
 	
 	private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
 	private static final AtomicBoolean IS_SWITCHING = new AtomicBoolean(false);
 	
+	private static final Pattern NUMBER_PATTERN = Pattern.compile("\\d+");
+	
 	private final Handler mainHandler = new Handler(Looper.getMainLooper());
+	
+	private static Method SHIZUKU_NEW_PROCESS_METHOD;
 	
 	private static Icon ICON_4G;
 	private static Icon ICON_5G;
@@ -50,12 +63,39 @@ public class NetworkTileService extends TileService {
 	private static Icon ICON_P4G;
 	private static Icon ICON_UNKNOWN;
 
-    @Override
-    public void onStartListening() {
-        super.onStartListening();
-        SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
-        updateTileUI(prefs.getInt(STATE_KEY, STATE_UNKNOWN));
-    }
+	@Override
+	public void onStartListening() {
+		super.onStartListening();
+
+		SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
+		int cachedState = prefs.getInt(STATE_KEY, STATE_UNKNOWN);
+
+		updateTileUI(cachedState);
+
+		int execMode = prefs.getInt(EXEC_MODE_KEY, MODE_NONE);
+		if (execMode == MODE_NONE) {
+			return;
+		}
+
+		// Lightweight behavior:
+		// Only read real system mode if we do not have a cached state yet.
+		if (cachedState != STATE_UNKNOWN) {
+			return;
+		}
+
+		EXECUTOR.execute(() -> {
+			int realState = readCurrentNetworkState();
+
+			mainHandler.post(() -> {
+				if (realState != STATE_UNKNOWN) {
+					prefs.edit().putInt(STATE_KEY, realState).apply();
+					updateTileUI(realState);
+				} else {
+					updateTileUI(cachedState);
+				}
+			});
+		});
+	}
 	
 	@Override
 	public void onClick() {
@@ -134,7 +174,31 @@ public class NetworkTileService extends TileService {
 				return BIN_4G_ONLY;
 		}
 	}
+	
+	private static Method getShizukuNewProcessMethod() throws NoSuchMethodException {
+		if (SHIZUKU_NEW_PROCESS_METHOD == null) {
+			SHIZUKU_NEW_PROCESS_METHOD = Shizuku.class.getDeclaredMethod(
+					"newProcess",
+					String[].class,
+					String[].class,
+					String.class
+			);
+			SHIZUKU_NEW_PROCESS_METHOD.setAccessible(true);
+		}
 
+		return SHIZUKU_NEW_PROCESS_METHOD;
+	}
+	
+	private static class CommandResult {
+		final int exitCode;
+		final String stdout;
+
+		CommandResult(int exitCode, String stdout) {
+			this.exitCode = exitCode;
+			this.stdout = stdout;
+		}
+	}
+	
     private Icon createTextOnlyIcon(String text) {
         int size = 256; 
         Bitmap bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888);
@@ -252,9 +316,150 @@ public class NetworkTileService extends TileService {
 		tile.updateTile();
 	}
 	
-	private int getDefaultDataSubId() {
-		return SubscriptionManager.getDefaultDataSubscriptionId();
+	private int readCurrentNetworkState() {
+		SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
+		int execMode = prefs.getInt(EXEC_MODE_KEY, MODE_NONE);
+
+		if (execMode == MODE_NONE) {
+			return STATE_UNKNOWN;
+		}
+
+		String command =
+				"data_sim=$(settings get global multi_sim_data_call); " +
+				"[ \"$data_sim\" -gt 0 ] 2>/dev/null || exit 1; " +
+				"settings get global preferred_network_mode${data_sim}";
+
+		CommandResult result;
+
+		if (execMode == MODE_SHIZUKU) {
+			result = runCommandForResultWithShizuku(command);
+		} else if (execMode == MODE_ROOT) {
+			result = runCommandForResultWithRoot(command);
+		} else {
+			return STATE_UNKNOWN;
+		}
+
+		if (result.exitCode != 0) {
+			return STATE_UNKNOWN;
+		}
+
+		return mapLegacyNetworkModeToState(result.stdout);
 	}
+	
+	private CommandResult runCommandForResultWithRoot(String command) {
+		Process process = null;
+
+		try {
+			process = Runtime.getRuntime().exec(new String[]{"su", "-c", command});
+
+			int exitCode = process.waitFor();
+			String stdout = readStream(process.getInputStream());
+
+			return new CommandResult(exitCode, stdout);
+		} catch (Exception e) {
+			return new CommandResult(-1, "");
+		} finally {
+			if (process != null) {
+				process.destroy();
+			}
+		}
+	}
+	
+	private CommandResult runCommandForResultWithShizuku(String command) {
+		Process process = null;
+
+		try {
+			if (!Shizuku.pingBinder()) {
+				return new CommandResult(-1, "");
+			}
+
+			if (Shizuku.checkSelfPermission() != android.content.pm.PackageManager.PERMISSION_GRANTED) {
+				return new CommandResult(-1, "");
+			}
+
+			process = (Process) getShizukuNewProcessMethod().invoke(
+				null,
+				new String[]{"sh", "-c", command},
+				null,
+				null
+			);
+
+			if (process == null) {
+				return new CommandResult(-1, "");
+			}
+
+			int exitCode = process.waitFor();
+			String stdout = readStream(process.getInputStream());
+
+			return new CommandResult(exitCode, stdout);
+		} catch (Exception e) {
+			return new CommandResult(-1, "");
+		} finally {
+			if (process != null) {
+				process.destroy();
+			}
+		}
+	}
+	
+	private String readStream(InputStream inputStream) {
+		StringBuilder builder = new StringBuilder();
+
+		try {
+			BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+			String line;
+
+			while ((line = reader.readLine()) != null) {
+				builder.append(line).append('\n');
+			}
+		} catch (Exception ignored) {
+		}
+
+		return builder.toString().trim();
+	}
+	
+	private Integer extractFirstInt(String text) {
+		try {
+			if (text == null || text.trim().isEmpty() || text.trim().equalsIgnoreCase("null")) {
+				return null;
+			}
+
+			Matcher matcher = NUMBER_PATTERN.matcher(text);
+
+			if (matcher.find()) {
+				return Integer.parseInt(matcher.group());
+			}
+
+			return null;
+		} catch (Exception e) {
+			return null;
+		}
+	}
+
+	private int mapLegacyNetworkModeToState(String output) {
+		Integer legacyMode = extractFirstInt(output);
+
+		if (legacyMode == null) {
+			return STATE_UNKNOWN;
+		}
+
+		switch (legacyMode) {
+			case LEGACY_4G_ONLY:
+				return STATE_4G_ONLY;
+
+			case LEGACY_5G_ONLY:
+				return STATE_5G_ONLY;
+
+			case LEGACY_PREF_5G:
+				return STATE_PREF_5G;
+
+			case LEGACY_PREF_4G:
+				return STATE_PREF_4G;
+
+			default:
+				return STATE_UNKNOWN;
+		}
+	}
+	
 	
 	private boolean applyNetworkMode(String binaryString) {
 		SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
@@ -264,13 +469,11 @@ public class NetworkTileService extends TileService {
 			return false;
 		}
 
-		int subId = getDefaultDataSubId();
-
-		if (subId == SubscriptionManager.INVALID_SUBSCRIPTION_ID) {
-			return false;
-		}
-
-		String command = "cmd phone set-allowed-network-types-for-users -s " + subId + " " + binaryString;
+		String command =
+				"data_sim=$(settings get global multi_sim_data_call); " +
+				"[ \"$data_sim\" -gt 0 ] 2>/dev/null || exit 1; " +
+				"phone_index=$((data_sim - 1)); " +
+				"cmd phone set-allowed-network-types-for-users -s \"$phone_index\" " + binaryString;
 
 		if (execMode == MODE_SHIZUKU) {
 			return runCommandWithShizuku(command);
@@ -282,17 +485,25 @@ public class NetworkTileService extends TileService {
 	}
 	
 	private boolean runCommandWithRoot(String command) {
+		Process process = null;
+
 		try {
-			Process process = Runtime.getRuntime().exec(new String[]{"su", "-c", command});
+			process = Runtime.getRuntime().exec(new String[]{"su", "-c", command});
 			int exitCode = process.waitFor();
 			return exitCode == 0;
 		} catch (Exception e) {
 			e.printStackTrace();
 			return false;
+		} finally {
+			if (process != null) {
+				process.destroy();
+			}
 		}
 	}
 	
 	private boolean runCommandWithShizuku(String command) {
+		Process process = null;
+		
 		try {
 			if (!Shizuku.pingBinder()) {
 				return false;
@@ -302,19 +513,11 @@ public class NetworkTileService extends TileService {
 				return false;
 			}
 
-			Method newProcessMethod = Shizuku.class.getDeclaredMethod(
-					"newProcess",
-					String[].class,
-					String[].class,
-					String.class
-			);
-			newProcessMethod.setAccessible(true);
-
-			Process process = (Process) newProcessMethod.invoke(
-					null,
-					new String[]{"sh", "-c", command},
-					null,
-					null
+			process = (Process) getShizukuNewProcessMethod().invoke(
+				null,
+				new String[]{"sh", "-c", command},
+				null,
+				null
 			);
 
 			if (process == null) {
@@ -327,6 +530,10 @@ public class NetworkTileService extends TileService {
 		} catch (Exception e) {
 			e.printStackTrace();
 			return false;
+		}finally {
+			if (process != null) {
+				process.destroy();
+			}
 		}
 	}
 }

--- a/app/src/main/java/com/dhangofa/networktoggle/NetworkTileService.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/NetworkTileService.java
@@ -11,6 +11,8 @@ import android.service.quicksettings.Tile;
 import android.service.quicksettings.TileService;
 import android.telephony.SubscriptionManager;
 import java.lang.reflect.Method;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import rikka.shizuku.Shizuku;
 
 public class NetworkTileService extends TileService {
@@ -34,6 +36,8 @@ public class NetworkTileService extends TileService {
     private static final String BIN_PREF_5G = "11011111101111111111"; // Legacy Id 33, bitmask 916479
     private static final String BIN_PREF_4G = "1001101001110000111"; // Legacy Id 9 , bitmask 316295
 	
+	private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
+	
 	private static Icon ICON_4G;
 	private static Icon ICON_5G;
 	private static Icon ICON_P5G;
@@ -46,32 +50,39 @@ public class NetworkTileService extends TileService {
         SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         updateTileUI(prefs.getInt(STATE_KEY, STATE_UNKNOWN));
     }
+	
+	@Override
+	public void onClick() {
+		super.onClick();
 
-    @Override
-    public void onClick() {
-        super.onClick();
-        SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
-		
+		SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
+
 		int execMode = prefs.getInt(EXEC_MODE_KEY, MODE_NONE);
 		if (execMode == MODE_NONE) {
 			updateTileUI(STATE_UNKNOWN);
 			return;
 		}
 
-        int currentState = prefs.getInt(STATE_KEY, STATE_UNKNOWN);
+		int currentState = prefs.getInt(STATE_KEY, STATE_UNKNOWN);
 
-        int nextState = getNextState(currentState);
+		int nextState = getNextState(currentState);
 		String targetBinary = getBinaryForState(nextState);
 
-        boolean success = applyNetworkMode(targetBinary);
+		updateTileSwitchingUI();
 
-        if (success) {
-			prefs.edit().putInt(STATE_KEY, nextState).apply();
-			updateTileUI(nextState);
-		} else {
-			updateTileUI(currentState);
-		}
-    }
+		EXECUTOR.execute(() -> {
+			boolean success = applyNetworkMode(targetBinary);
+
+			getMainExecutor().execute(() -> {
+				if (success) {
+					prefs.edit().putInt(STATE_KEY, nextState).apply();
+					updateTileUI(nextState);
+				} else {
+					updateTileUI(currentState);
+				}
+			});
+		});
+	}
 	
 	private int getNextState(int currentState) {
 		switch (currentState) {
@@ -164,6 +175,16 @@ public class NetworkTileService extends TileService {
 				}
 				return ICON_UNKNOWN;
 		}
+	}
+	
+	private void updateTileSwitchingUI() {
+		Tile tile = getQsTile();
+		if (tile == null) return;
+
+		tile.setState(Tile.STATE_INACTIVE);
+		tile.setLabel("Switching...");
+		tile.setIcon(getCachedIcon("?"));
+		tile.updateTile();
 	}
 
     private void updateTileUI(int state) {

--- a/app/src/main/java/com/dhangofa/networktoggle/NetworkTileService.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/NetworkTileService.java
@@ -9,7 +9,6 @@ import android.graphics.Typeface;
 import android.graphics.drawable.Icon;
 import android.service.quicksettings.Tile;
 import android.service.quicksettings.TileService;
-import java.io.DataOutputStream;
 import java.lang.reflect.Method;
 import rikka.shizuku.Shizuku;
 
@@ -63,10 +62,14 @@ public class NetworkTileService extends TileService {
         int nextState = getNextState(currentState);
 		String targetBinary = getBinaryForState(nextState);
 
-        applyNetworkMode(targetBinary);
+        boolean success = applyNetworkMode(targetBinary);
 
-        prefs.edit().putInt(STATE_KEY, nextState).apply();
-        updateTileUI(nextState);
+        if (success) {
+			prefs.edit().putInt(STATE_KEY, nextState).apply();
+			updateTileUI(nextState);
+		} else {
+			updateTileUI(currentState);
+		}
     }
 	
 	private int getNextState(int currentState) {
@@ -193,49 +196,89 @@ public class NetworkTileService extends TileService {
 
 			case STATE_UNKNOWN:
 			default:
-				tile.setState(Tile.STATE_UNAVAILABLE);
-				tile.setLabel("Net Mode ?");
+				SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
+				int execMode = prefs.getInt(EXEC_MODE_KEY, MODE_NONE);
+
+				if (execMode == MODE_NONE) {
+					tile.setState(Tile.STATE_UNAVAILABLE);
+					tile.setLabel("Setup Required");
+				} else {
+					tile.setState(Tile.STATE_INACTIVE);
+					tile.setLabel("Tap to Set 4G");
+				}
+
 				tile.setIcon(getCachedIcon("?"));
 				break;
 		}
 
 		tile.updateTile();
 	}
+	
+	private boolean applyNetworkMode(String binaryString) {
+		SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
+		int execMode = prefs.getInt(EXEC_MODE_KEY, MODE_NONE);
 
-    private void applyNetworkMode(String binaryString) {
-        SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
-        int execMode = prefs.getInt(EXEC_MODE_KEY, MODE_NONE);
-        String command = "cmd phone set-allowed-network-types-for-users -s 0 " + binaryString;
+		if (execMode == MODE_NONE) {
+			return false;
+		}
 
-        if (execMode == MODE_SHIZUKU) {
-            // Shizuku Execution Method via Reflection
-            try {
-                if (Shizuku.pingBinder() && Shizuku.checkSelfPermission() == android.content.pm.PackageManager.PERMISSION_GRANTED) {
-                    
-                    // Uses Reflection to bypass the private access restriction on Shizuku.newProcess
-                    Method newProcessMethod = Shizuku.class.getDeclaredMethod("newProcess", String[].class, String[].class, String.class);
-                    newProcessMethod.setAccessible(true);
-                    
-                    Process process = (Process) newProcessMethod.invoke(null, new String[]{"sh", "-c", command}, null, null);
-                    if (process != null) {
-                        process.waitFor();
-                    }
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        } else if (execMode == MODE_ROOT) {
-            // Standard Root Execution Method
-            try {
-                Process process = Runtime.getRuntime().exec("su");
-                DataOutputStream os = new DataOutputStream(process.getOutputStream());
-                os.writeBytes(command + "\n");
-                os.writeBytes("exit\n");
-                os.flush();
-                process.waitFor();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
-    }
+		String command = "cmd phone set-allowed-network-types-for-users -s 0 " + binaryString;
+
+		if (execMode == MODE_SHIZUKU) {
+			return runCommandWithShizuku(command);
+		} else if (execMode == MODE_ROOT) {
+			return runCommandWithRoot(command);
+		}
+
+		return false;
+	}
+	
+	private boolean runCommandWithRoot(String command) {
+		try {
+			Process process = Runtime.getRuntime().exec(new String[]{"su", "-c", command});
+			int exitCode = process.waitFor();
+			return exitCode == 0;
+		} catch (Exception e) {
+			e.printStackTrace();
+			return false;
+		}
+	}
+	
+	private boolean runCommandWithShizuku(String command) {
+		try {
+			if (!Shizuku.pingBinder()) {
+				return false;
+			}
+
+			if (Shizuku.checkSelfPermission() != android.content.pm.PackageManager.PERMISSION_GRANTED) {
+				return false;
+			}
+
+			Method newProcessMethod = Shizuku.class.getDeclaredMethod(
+					"newProcess",
+					String[].class,
+					String[].class,
+					String.class
+			);
+			newProcessMethod.setAccessible(true);
+
+			Process process = (Process) newProcessMethod.invoke(
+					null,
+					new String[]{"sh", "-c", command},
+					null,
+					null
+			);
+
+			if (process == null) {
+				return false;
+			}
+
+			int exitCode = process.waitFor();
+			return exitCode == 0;
+
+		} catch (Exception e) {
+			e.printStackTrace();
+			return false;
+		}
+	}
 }

--- a/app/src/main/java/com/dhangofa/networktoggle/NetworkTileService.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/NetworkTileService.java
@@ -10,6 +10,9 @@ import android.graphics.drawable.Icon;
 import android.service.quicksettings.Tile;
 import android.service.quicksettings.TileService;
 import android.telephony.SubscriptionManager;
+import android.os.Handler;
+import android.os.Looper;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.lang.reflect.Method;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -37,6 +40,9 @@ public class NetworkTileService extends TileService {
     private static final String BIN_PREF_4G = "1001101001110000111"; // Legacy Id 9 , bitmask 316295
 	
 	private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
+	private static final AtomicBoolean IS_SWITCHING = new AtomicBoolean(false);
+	
+	private final Handler mainHandler = new Handler(Looper.getMainLooper());
 	
 	private static Icon ICON_4G;
 	private static Icon ICON_5G;
@@ -55,10 +61,16 @@ public class NetworkTileService extends TileService {
 	public void onClick() {
 		super.onClick();
 
+		if (!IS_SWITCHING.compareAndSet(false, true)) {
+			updateTileSwitchingUI();
+			return;
+		}
+
 		SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
 
 		int execMode = prefs.getInt(EXEC_MODE_KEY, MODE_NONE);
 		if (execMode == MODE_NONE) {
+			IS_SWITCHING.set(false);
 			updateTileUI(STATE_UNKNOWN);
 			return;
 		}
@@ -73,12 +85,16 @@ public class NetworkTileService extends TileService {
 		EXECUTOR.execute(() -> {
 			boolean success = applyNetworkMode(targetBinary);
 
-			getMainExecutor().execute(() -> {
-				if (success) {
-					prefs.edit().putInt(STATE_KEY, nextState).apply();
-					updateTileUI(nextState);
-				} else {
-					updateTileUI(currentState);
+			mainHandler.post(() -> {
+				try {
+					if (success) {
+						prefs.edit().putInt(STATE_KEY, nextState).apply();
+						updateTileUI(nextState);
+					} else {
+						updateTileUI(currentState);
+					}
+				} finally {
+					IS_SWITCHING.set(false);
 				}
 			});
 		});

--- a/app/src/main/java/com/dhangofa/networktoggle/NetworkTileService.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/NetworkTileService.java
@@ -9,6 +9,7 @@ import android.graphics.Typeface;
 import android.graphics.drawable.Icon;
 import android.service.quicksettings.Tile;
 import android.service.quicksettings.TileService;
+import android.telephony.SubscriptionManager;
 import java.lang.reflect.Method;
 import rikka.shizuku.Shizuku;
 
@@ -28,10 +29,10 @@ public class NetworkTileService extends TileService {
 	private static final int STATE_PREF_5G = 3;
 	private static final int STATE_PREF_4G = 4;
 
-    private static final String BIN_4G_ONLY = "1000000000000"; // Legacy Id 11 (4096)
-    private static final String BIN_5G_ONLY = "10000000000000000000"; // Legacy Id 23 (524288)
-    private static final String BIN_PREF_5G = "11011111101111111111"; // Legacy Id 33 (916479)
-    private static final String BIN_PREF_4G = "1001101001110000111"; // Legacy Id 9 (316295)
+    private static final String BIN_4G_ONLY = "1000000000000"; // Legacy Id 11, bitmask 4096
+    private static final String BIN_5G_ONLY = "10000000000000000000"; // Legacy Id 23, bitmask 524288
+    private static final String BIN_PREF_5G = "11011111101111111111"; // Legacy Id 33, bitmask 916479
+    private static final String BIN_PREF_4G = "1001101001110000111"; // Legacy Id 9 , bitmask 316295
 	
 	private static Icon ICON_4G;
 	private static Icon ICON_5G;
@@ -214,6 +215,10 @@ public class NetworkTileService extends TileService {
 		tile.updateTile();
 	}
 	
+	private int getDefaultDataSubId() {
+		return SubscriptionManager.getDefaultDataSubscriptionId();
+	}
+	
 	private boolean applyNetworkMode(String binaryString) {
 		SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
 		int execMode = prefs.getInt(EXEC_MODE_KEY, MODE_NONE);
@@ -222,7 +227,13 @@ public class NetworkTileService extends TileService {
 			return false;
 		}
 
-		String command = "cmd phone set-allowed-network-types-for-users -s 0 " + binaryString;
+		int subId = getDefaultDataSubId();
+
+		if (subId == SubscriptionManager.INVALID_SUBSCRIPTION_ID) {
+			return false;
+		}
+
+		String command = "cmd phone set-allowed-network-types-for-users -s " + subId + " " + binaryString;
 
 		if (execMode == MODE_SHIZUKU) {
 			return runCommandWithShizuku(command);

--- a/app/src/main/java/com/dhangofa/networktoggle/NetworkTileService.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/NetworkTileService.java
@@ -18,40 +18,91 @@ public class NetworkTileService extends TileService {
     private static final String PREFS_NAME = "NetTogglePrefs";
     private static final String STATE_KEY = "net_state";
     private static final String EXEC_MODE_KEY = "exec_mode";
+	
+	private static final int MODE_NONE = 0;
+	private static final int MODE_ROOT = 1;
+	private static final int MODE_SHIZUKU = 2;
+	
+	private static final int STATE_UNKNOWN = 0;
+	private static final int STATE_4G_ONLY = 1;
+	private static final int STATE_5G_ONLY = 2;
+	private static final int STATE_PREF_5G = 3;
+	private static final int STATE_PREF_4G = 4;
 
-    private static final String BIN_4G_ONLY = "1000000000000";
-    private static final String BIN_5G_ONLY = "10000000000000000000";
-    private static final String BIN_PREF_5G = "11011111101111111111"; 
-    private static final String BIN_PREF_4G = "1001101001110000111";  
+    private static final String BIN_4G_ONLY = "1000000000000"; // Legacy Id 11 (4096)
+    private static final String BIN_5G_ONLY = "10000000000000000000"; // Legacy Id 23 (524288)
+    private static final String BIN_PREF_5G = "11011111101111111111"; // Legacy Id 33 (916479)
+    private static final String BIN_PREF_4G = "1001101001110000111"; // Legacy Id 9 (316295)
+	
+	private static Icon ICON_4G;
+	private static Icon ICON_5G;
+	private static Icon ICON_P5G;
+	private static Icon ICON_P4G;
+	private static Icon ICON_UNKNOWN;
 
     @Override
     public void onStartListening() {
         super.onStartListening();
         SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
-        updateTileUI(prefs.getInt(STATE_KEY, 1));
+        updateTileUI(prefs.getInt(STATE_KEY, STATE_UNKNOWN));
     }
 
     @Override
     public void onClick() {
         super.onClick();
         SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
-        int currentState = prefs.getInt(STATE_KEY, 1);
+		
+		int execMode = prefs.getInt(EXEC_MODE_KEY, MODE_NONE);
+		if (execMode == MODE_NONE) {
+			updateTileUI(STATE_UNKNOWN);
+			return;
+		}
 
-        int nextState = (currentState % 4) + 1;
-        String targetBinary = BIN_4G_ONLY;
+        int currentState = prefs.getInt(STATE_KEY, STATE_UNKNOWN);
 
-        switch (nextState) {
-            case 1: targetBinary = BIN_4G_ONLY; break; 
-            case 2: targetBinary = BIN_5G_ONLY; break; 
-            case 3: targetBinary = BIN_PREF_5G; break; 
-            case 4: targetBinary = BIN_PREF_4G; break; 
-        }
+        int nextState = getNextState(currentState);
+		String targetBinary = getBinaryForState(nextState);
 
         applyNetworkMode(targetBinary);
 
         prefs.edit().putInt(STATE_KEY, nextState).apply();
         updateTileUI(nextState);
     }
+	
+	private int getNextState(int currentState) {
+		switch (currentState) {
+			case STATE_4G_ONLY:
+				return STATE_5G_ONLY;
+
+			case STATE_5G_ONLY:
+				return STATE_PREF_5G;
+
+			case STATE_PREF_5G:
+				return STATE_PREF_4G;
+
+			case STATE_PREF_4G:
+			case STATE_UNKNOWN:
+			default:
+				return STATE_4G_ONLY;
+		}
+	}
+	
+	private String getBinaryForState(int state) {
+		switch (state) {
+			case STATE_5G_ONLY:
+				return BIN_5G_ONLY;
+
+			case STATE_PREF_5G:
+				return BIN_PREF_5G;
+
+			case STATE_PREF_4G:
+				return BIN_PREF_4G;
+
+			case STATE_4G_ONLY:
+			default:
+				return BIN_4G_ONLY;
+		}
+	}
 
     private Icon createTextOnlyIcon(String text) {
         int size = 256; 
@@ -76,39 +127,87 @@ public class NetworkTileService extends TileService {
 
         return Icon.createWithBitmap(bitmap);
     }
+	
+	private Icon getCachedIcon(String text) {
+		switch (text) {
+			case "4G":
+				if (ICON_4G == null) {
+					ICON_4G = createTextOnlyIcon("4G");
+				}
+				return ICON_4G;
+
+			case "5G":
+				if (ICON_5G == null) {
+					ICON_5G = createTextOnlyIcon("5G");
+				}
+				return ICON_5G;
+
+			case "P5G":
+				if (ICON_P5G == null) {
+					ICON_P5G = createTextOnlyIcon("P5G");
+				}
+				return ICON_P5G;
+
+			case "P4G":
+				if (ICON_P4G == null) {
+					ICON_P4G = createTextOnlyIcon("P4G");
+				}
+				return ICON_P4G;
+
+			default:
+				if (ICON_UNKNOWN == null) {
+					ICON_UNKNOWN = createTextOnlyIcon("?");
+				}
+				return ICON_UNKNOWN;
+		}
+	}
 
     private void updateTileUI(int state) {
-        Tile tile = getQsTile();
-        if (tile == null) return;
-        tile.setState(Tile.STATE_ACTIVE);
+		Tile tile = getQsTile();
+		if (tile == null) return;
 
-        switch (state) {
-            case 1: 
-                tile.setLabel("4G Only");
-                tile.setIcon(createTextOnlyIcon("4G"));
-                break;
-            case 2: 
-                tile.setLabel("5G Only");
-                tile.setIcon(createTextOnlyIcon("5G"));
-                break;
-            case 3: 
-                tile.setLabel("Pref 5G");
-                tile.setIcon(createTextOnlyIcon("P5G"));
-                break;
-            case 4: 
-                tile.setLabel("Pref 4G");
-                tile.setIcon(createTextOnlyIcon("P4G"));
-                break;
-        }
-        tile.updateTile();
-    }
+		switch (state) {
+			case STATE_4G_ONLY:
+				tile.setState(Tile.STATE_ACTIVE);
+				tile.setLabel("4G Only");
+				tile.setIcon(getCachedIcon("4G"));
+				break;
+
+			case STATE_5G_ONLY:
+				tile.setState(Tile.STATE_ACTIVE);
+				tile.setLabel("5G Only");
+				tile.setIcon(getCachedIcon("5G"));
+				break;
+
+			case STATE_PREF_5G:
+				tile.setState(Tile.STATE_ACTIVE);
+				tile.setLabel("Pref 5G");
+				tile.setIcon(getCachedIcon("P5G"));
+				break;
+
+			case STATE_PREF_4G:
+				tile.setState(Tile.STATE_ACTIVE);
+				tile.setLabel("Pref 4G");
+				tile.setIcon(getCachedIcon("P4G"));
+				break;
+
+			case STATE_UNKNOWN:
+			default:
+				tile.setState(Tile.STATE_UNAVAILABLE);
+				tile.setLabel("Net Mode ?");
+				tile.setIcon(getCachedIcon("?"));
+				break;
+		}
+
+		tile.updateTile();
+	}
 
     private void applyNetworkMode(String binaryString) {
         SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
-        int execMode = prefs.getInt(EXEC_MODE_KEY, 1); // 1 = Root, 2 = Shizuku
+        int execMode = prefs.getInt(EXEC_MODE_KEY, MODE_NONE);
         String command = "cmd phone set-allowed-network-types-for-users -s 0 " + binaryString;
 
-        if (execMode == 2) {
+        if (execMode == MODE_SHIZUKU) {
             // Shizuku Execution Method via Reflection
             try {
                 if (Shizuku.pingBinder() && Shizuku.checkSelfPermission() == android.content.pm.PackageManager.PERMISSION_GRANTED) {
@@ -125,7 +224,7 @@ public class NetworkTileService extends TileService {
             } catch (Exception e) {
                 e.printStackTrace();
             }
-        } else {
+        } else if (execMode == MODE_ROOT) {
             // Standard Root Execution Method
             try {
                 Process process = Runtime.getRuntime().exec("su");


### PR DESCRIPTION
## Summary

This PR merges the dev branch improvements into main to make NetToggle safer, lighter, and more reliable for Root/Shizuku based network mode switching.

The update improves execution mode handling, Root/Shizuku permission flow, QS tile state accuracy, command execution safety, icon caching, SIM handling, and lifecycle cleanup.

## MainActivity changes

- Added explicit execution mode constants:
  - `MODE_NONE`
  - `MODE_ROOT`
  - `MODE_SHIZUKU`
- Changed fresh install behavior so no execution mode is selected by default.
- Removed old behavior that automatically selected Root mode on first launch.
- Added Root permission check when Root mode is selected or restored.
- Re-checks Root permission when saved Root mode is opened again.
- Changed Shizuku permission flow so permission is requested only when user selects Shizuku mode.
- Saved Shizuku mode now checks status without automatically triggering the permission popup.
- Guarded Shizuku binder callbacks so they only update UI when:
  - Activity is still alive
  - Shizuku mode is currently selected
- Added Activity destroyed flag to prevent stale UI updates after MainActivity closes.
- Tracked Root permission check thread and process.
- Destroyed active Root check process during `onDestroy()`.
- Interrupted active Root check thread during Activity cleanup.
- Preserved Shizuku listener cleanup in `onDestroy()`.
- Prevented stale Root permission results from overwriting current selected mode.

## NetworkTileService changes

- Added explicit execution mode constants and network state constants.
- Added `STATE_UNKNOWN` to avoid assuming 4G Only on first install.
- Updated QS tile startup to show cached state instead of blindly assuming mode.
- Cached generated QS tile icons to avoid recreating Bitmap/Icon objects on every tile update.
- Added unknown/setup tile state handling.
- Refactored network mode cycling into `getNextState()`.
- Refactored binary mode selection into `getBinaryForState()`.
- Changed network command execution to return success/failure.
- Updated tile state only after successful command execution.
- Preserved previous tile state when command execution fails.
- Moved Root/Shizuku command execution off the QS tile click path using a background executor.
- Added immediate "Switching..." tile feedback while command is running.
- Added main-thread Handler updates for Android 7+ compatibility.
- Added AtomicBoolean guard to prevent rapid repeated taps from queueing duplicate commands.
- Replaced hardcoded SIM handling with active data SIM detection using `multi_sim_data_call`.
- Mapped active data SIM index to phone command index:
  - `multi_sim_data_call=1` -> `cmd phone -s 0`
  - `multi_sim_data_call=2` -> `cmd phone -s 1`
- Reads current mode from `preferred_network_mode1/2` using legacy mode IDs.
- Added legacy mode ID mapping:
  - `11` -> 4G Only
  - `23` -> 5G Only
  - `33` -> Preferred 5G
  - `9` -> Preferred 4G
- Avoided running real network mode checks on every QS panel open.
- Real current mode is queried only when cached tile state is unknown.
- Cached Shizuku `newProcess` reflection Method to avoid repeated reflection lookup.
- Cached regex Pattern used for legacy mode parsing.
- Removed unused stderr storage from command result handling.
- Added Root/Shizuku process cleanup after command execution.

## Performance impact

- Reduces CPU overhead during QS panel refresh.
- Avoids unnecessary shell/Shizuku command execution on every QS pull-down.
- Avoids repeated bitmap/icon generation.
- Prevents duplicate toggle commands from rapid taps.
- Avoids blocking the QS tile callback thread.
- Keeps tile state updates dependent on actual command success.

## Reliability impact

- Fresh install no longer assumes Root mode or 4G state.
- Root/Shizuku mode selection is safer and more explicit.
- Tile no longer shows a changed state when command execution fails.
- Active data SIM handling is improved.
- MainActivity and TileService lifecycle cleanup is safer.
- Android 7+ compatibility is improved by avoiding API 28-only main executor usage.

## Testing

Tested expected flows:

- Fresh install starts with no selected execution mode.
- Root mode checks Root access before reporting authorized state.
- Shizuku mode requests permission only after user selection.
- Saved Root/Shizuku modes restore safely.
- QS tile toggles modes asynchronously.
- QS tile shows "Switching..." while command is running.
- Failed command does not update cached tile state.
- Rapid repeated tile taps do not queue duplicate commands.
- Current mode detection works from legacy `preferred_network_mode1/2` values.
