### PR TITLE
Add automatic PR validation to release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,53 +3,117 @@ name: Build and Automate NetToggle Release
 on:
   workflow_dispatch:
 
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v4
+      - name: Checkout Code
+        uses: actions/checkout@v6
 
-    - name: Set up Java Development Kit (JDK)
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
+      - name: Set up Java Development Kit
+        uses: actions/setup-java@v5
+        with:
+          java-version: "17"
+          distribution: temurin
 
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-provider: basic
 
-    - name: Accept Licenses and Install SDK 36
-      run: |
-        yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses || true
-        $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "platforms;android-36"
+      - name: Accept Licenses and Install SDK 36
+        run: |
+          yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses || true
+          "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" "platforms;android-36"
 
-    - name: Make Gradle Wrapper executable
-      run: chmod +x ./gradlew
-      
-    - name: Compile Release APK using Gradle Wrapper
-      run: ./gradlew assembleRelease
+      - name: Make Gradle Wrapper Executable
+        run: chmod +x ./gradlew
 
-    - name: Decode Permanent Keystore
-      run: |
-        cat << 'EOF' > encoded_key.txt
-        ${{ secrets.KEYSTORE_BASE64 }}
-        EOF
-        sed -i '/---/d' encoded_key.txt
-        tr -d '\r\n ' < encoded_key.txt | base64 --decode > release.keystore
+      - name: Compile Release APK
+        run: ./gradlew assembleRelease
 
-    - name: Zipalign and Sign Release APK (V2 Signature)
-      run: |
-        BUILD_TOOLS_DIR=$(ls -d $ANDROID_HOME/build-tools/* | tail -1)
-        
-        $BUILD_TOOLS_DIR/zipalign -v -p 4 app/build/outputs/apk/release/app-release-unsigned.apk app/build/outputs/apk/release/app-release-aligned.apk
-        
-        $BUILD_TOOLS_DIR/apksigner sign --ks release.keystore --ks-pass pass:${{ secrets.KEYSTORE_PASSWORD }} --out app/build/outputs/apk/release/NetToggle.apk app/build/outputs/apk/release/app-release-aligned.apk
+      - name: Upload Unsigned APK
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/upload-artifact@v6
+        with:
+          name: NetToggle-Unsigned-Package
+          path: app/build/outputs/apk/release/app-release-unsigned.apk
+          compression-level: 0
+          if-no-files-found: error
 
-    - name: Upload APK as Build Artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: NetToggle-Package
-        path: app/build/outputs/apk/release/NetToggle.apk
-        compression-level: 0
+      - name: Decode Permanent Keystore
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+        run: |
+          printf '%s' "$KEYSTORE_BASE64" \
+            | sed '/---/d' \
+            | tr -d '\r\n ' \
+            | base64 --decode \
+            > release.keystore
+
+          test -s release.keystore
+
+      - name: Zipalign and Sign Release APK
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+        run: |
+          BUILD_TOOLS_DIR="$(find "$ANDROID_HOME/build-tools" \
+            -mindepth 1 -maxdepth 1 -type d \
+            | sort -V \
+            | tail -n 1)"
+
+          "$BUILD_TOOLS_DIR/zipalign" -v -p 4 \
+            app/build/outputs/apk/release/app-release-unsigned.apk \
+            app/build/outputs/apk/release/app-release-aligned.apk
+
+          "$BUILD_TOOLS_DIR/apksigner" sign \
+            --ks release.keystore \
+            --ks-pass env:KEYSTORE_PASSWORD \
+            --out app/build/outputs/apk/release/NetToggle.apk \
+            app/build/outputs/apk/release/app-release-aligned.apk
+
+      - name: Verify Signed APK
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          BUILD_TOOLS_DIR="$(find "$ANDROID_HOME/build-tools" \
+            -mindepth 1 -maxdepth 1 -type d \
+            | sort -V \
+            | tail -n 1)"
+
+          "$BUILD_TOOLS_DIR/apksigner" verify \
+            --verbose \
+            --print-certs \
+            app/build/outputs/apk/release/NetToggle.apk
+
+      - name: Generate APK SHA-256
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          cd app/build/outputs/apk/release
+          sha256sum NetToggle.apk > NetToggle.apk.sha256
+          cat NetToggle.apk.sha256
+
+      - name: Upload Signed APK
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v6
+        with:
+          name: NetToggle-Package
+          path: |
+            app/build/outputs/apk/release/NetToggle.apk
+            app/build/outputs/apk/release/NetToggle.apk.sha256
+          compression-level: 0
+          if-no-files-found: error
+
+      - name: Remove Decoded Keystore
+        if: always() && github.event_name == 'workflow_dispatch'
+        run: rm -f release.keystore


### PR DESCRIPTION
- Added automatic release compilation for pull requests targeting main.
- Restricted APK signing to manually triggered release builds.
- Updated GitHub Actions to Node.js 24-compatible versions.
- Added signed APK verification and SHA-256 generation.
- Added decoded keystore cleanup.
- Added minimal read-only workflow permissions.
- Preserved the Gradle 8.7 Wrapper build process.