### PR TITLE
Native API Fast-Paths, Dynamic Capability Filtering, UI Overhaul and Diagnostic Tracking

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "com.dhangofa.networktoggle"
         minSdk = 24
         targetSdk = 36
-        versionCode = 32
-        versionName = "1.0.32"
+        versionCode = 65
+        versionName = "1.0.65"
     }
     // Suggested by IzzyOnDroid
     dependenciesInfo {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
 
     <!-- Used only to clear stale cached QS tile state after reboot -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
 
     <application
         android:allowBackup="false"

--- a/app/src/main/java/com/dhangofa/networktoggle/MainActivity.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/MainActivity.java
@@ -57,6 +57,10 @@ public class MainActivity extends Activity {
     private RadioButton radioSim1;
     private RadioButton radioSim2;
     private TextView autoSimWarningText;
+	
+	private View separatorRootShizuku;
+    private View separatorAutoSim1;
+    private View separatorSim1Sim2;
 
     private AppPreferences appPreferences;
 	private TileCycleUiController tileCycleUiController;	
@@ -111,6 +115,7 @@ public class MainActivity extends Activity {
         loadSavedTargetSimMode();
         updateAutoSimWarning();
         bindSelectionListeners();
+		updateSeparatorVisibility();
     }
 
     private void configureStatusBar() {
@@ -118,7 +123,7 @@ public class MainActivity extends Activity {
 
         boolean isNight = (getResources().getConfiguration().uiMode
                 & Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES;
-        getWindow().setStatusBarColor(getColor(R.color.surface_background));
+        getWindow().setStatusBarColor(getColor(R.color.card_surface));
         getWindow().getDecorView().setSystemUiVisibility(
                 isNight ? 0 : View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
     }
@@ -136,11 +141,40 @@ public class MainActivity extends Activity {
         autoSimWarningText = findViewById(R.id.autoSimWarningText);
         githubLink = findViewById(R.id.githubLink);
         telegramLink = findViewById(R.id.telegramLink);
+		separatorRootShizuku = findViewById(R.id.separatorRootShizuku);
+        separatorAutoSim1 = findViewById(R.id.separatorAutoSim1);
+        separatorSim1Sim2 = findViewById(R.id.separatorSim1Sim2);
     }
 
     private void bindLinks() {
         githubLink.setOnClickListener(v -> openUrl("https://github.com/Dhangofa/NetToggle"));
-        telegramLink.setOnClickListener(v -> openUrl("https://t.me/dhangofa"));
+        telegramLink.setOnClickListener(v -> openUrl("https://t.me/dhangofas_projects_chat"));
+    }
+	
+	private void updateSeparatorVisibility() {
+        // Execution Mode Separator
+        int modeId = radioGroup.getCheckedRadioButtonId();
+        if (modeId == -1) {
+            separatorRootShizuku.setVisibility(View.VISIBLE);
+        } else {
+            separatorRootShizuku.setVisibility(View.INVISIBLE);
+        }
+
+        // Target SIM Separators
+        int simId = targetSimRadioGroup.getCheckedRadioButtonId();
+        if (simId == -1) {
+            separatorAutoSim1.setVisibility(View.VISIBLE);
+            separatorSim1Sim2.setVisibility(View.VISIBLE);
+        } else if (simId == R.id.radioSimAuto) {
+            separatorAutoSim1.setVisibility(View.INVISIBLE);
+            separatorSim1Sim2.setVisibility(View.VISIBLE);
+        } else if (simId == R.id.radioSim1) {
+            separatorAutoSim1.setVisibility(View.INVISIBLE);
+            separatorSim1Sim2.setVisibility(View.INVISIBLE);
+        } else if (simId == R.id.radioSim2) {
+            separatorAutoSim1.setVisibility(View.VISIBLE);
+            separatorSim1Sim2.setVisibility(View.INVISIBLE);
+        }
     }
 
     private void registerShizukuListeners() {
@@ -165,6 +199,7 @@ public class MainActivity extends Activity {
 
     private void bindSelectionListeners() {
         radioGroup.setOnCheckedChangeListener((group, checkedId) -> {
+			updateSeparatorVisibility();
             if (checkedId == R.id.radioRoot) {
                 appPreferences.onExecutionModeChanged(ExecutionMode.ROOT);
                 checkRootPermission();
@@ -175,6 +210,7 @@ public class MainActivity extends Activity {
         });
 
         targetSimRadioGroup.setOnCheckedChangeListener((group, checkedId) -> {
+			updateSeparatorVisibility();
             TargetSim target = TargetSim.AUTO;
             if (checkedId == R.id.radioSim1) target = TargetSim.SIM_1;
             else if (checkedId == R.id.radioSim2) target = TargetSim.SIM_2;

--- a/app/src/main/java/com/dhangofa/networktoggle/MainActivity.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/MainActivity.java
@@ -35,14 +35,29 @@ import android.widget.TextView;
 
 import com.dhangofa.networktoggle.config.AppPreferences;
 import com.dhangofa.networktoggle.model.ExecutionMode;
+import com.dhangofa.networktoggle.model.NetworkMode;
 import com.dhangofa.networktoggle.model.TargetSim;
 import com.dhangofa.networktoggle.cycle.TileCycleManager;
+import com.dhangofa.networktoggle.telephony.NetworkModeController;
+import com.dhangofa.networktoggle.telephony.NetworkCapabilityResolver;
+import com.dhangofa.networktoggle.telephony.SimResolver;
 import com.dhangofa.networktoggle.ui.TileCycleUiController;
+import android.app.Dialog;
+import android.view.Gravity;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.widget.Toast;
+import com.dhangofa.networktoggle.model.DiagnosticError;
+import com.dhangofa.networktoggle.util.DiagnosticReporter;
 
 
 import rikka.shizuku.Shizuku;
 
-public class MainActivity extends Activity {	
+public class MainActivity extends Activity implements android.content.SharedPreferences.OnSharedPreferenceChangeListener {	
 	
     private RadioGroup radioGroup;
     private RadioButton radioRoot;
@@ -61,6 +76,13 @@ public class MainActivity extends Activity {
 	private View separatorRootShizuku;
     private View separatorAutoSim1;
     private View separatorSim1Sim2;
+
+    private Dialog permissionDialog;
+    private View errorBannerContainer;
+    private Dialog diagnosticDialog;
+    private NetworkCapabilityResolver capabilityResolver;
+    
+    private static final int REQ_CODE_PHONE_STATE = 1001;
 
     private AppPreferences appPreferences;
 	private TileCycleUiController tileCycleUiController;	
@@ -104,11 +126,37 @@ public class MainActivity extends Activity {
         setContentView(R.layout.activity_main);
 
         appPreferences = new AppPreferences(this);
+        appPreferences.registerListener(this);
         bindViews();
 		appVersionText.setText("v" + getAppVersionName());
         bindLinks();
+        SimResolver simResolver = new SimResolver(this, appPreferences);
+        capabilityResolver = new NetworkCapabilityResolver(appPreferences, simResolver);
 		TileCycleManager tileCycleManager = new TileCycleManager(appPreferences);
 		tileCycleUiController = new TileCycleUiController(this, tileCycleManager);
+        NetworkModeController modeController = new NetworkModeController(simResolver);
+        
+        tileCycleUiController.setOnCycleChangedListener(newCycle -> {
+            new Thread(() -> {
+                NetworkMode currentMode = appPreferences.getCachedNetworkMode();
+                
+                // If cache is wiped (e.g. from SIM switch), but execution is allowed, read it directly once
+                if (currentMode == NetworkMode.UNKNOWN && appPreferences.getExecutionMode() != ExecutionMode.NONE) {
+                    currentMode = new com.dhangofa.networktoggle.telephony.NetworkModeReader(this, appPreferences, simResolver).readCurrentMode();
+                }
+
+                if (currentMode != NetworkMode.UNKNOWN && !newCycle.contains(currentMode)) {
+                    NetworkMode fallbackMode = newCycle.get(0);
+                    // Attempt to sync the network state silently
+                    modeController.apply(fallbackMode, appPreferences.getExecutionMode());
+                    appPreferences.setCachedNetworkMode(fallbackMode);
+                } else if (currentMode != NetworkMode.UNKNOWN) {
+                    // It's in the cycle, ensure it is cached so UI shows the actual active state
+                    appPreferences.setCachedNetworkMode(currentMode);
+                }
+            }).start();
+        });
+
 		tileCycleUiController.initialize();
         registerShizukuListeners();
         loadSavedExecutionMode();
@@ -144,6 +192,13 @@ public class MainActivity extends Activity {
 		separatorRootShizuku = findViewById(R.id.separatorRootShizuku);
         separatorAutoSim1 = findViewById(R.id.separatorAutoSim1);
         separatorSim1Sim2 = findViewById(R.id.separatorSim1Sim2);
+
+        errorBannerContainer = findViewById(R.id.cardErrorBanner);
+        if (errorBannerContainer != null) {
+            errorBannerContainer.setOnClickListener(v -> showDiagnosticDialog());
+        }
+        
+        
     }
 
     private void bindLinks() {
@@ -197,6 +252,8 @@ public class MainActivity extends Activity {
         }
     }
 
+    private boolean updatingSimUi = false;
+
     private void bindSelectionListeners() {
         radioGroup.setOnCheckedChangeListener((group, checkedId) -> {
 			updateSeparatorVisibility();
@@ -209,13 +266,51 @@ public class MainActivity extends Activity {
             }
         });
 
+        android.view.View.OnTouchListener lockTouch = (v, event) -> {
+            if (!isUIAuthorized && event.getAction() == android.view.MotionEvent.ACTION_DOWN) {
+                android.widget.Toast.makeText(MainActivity.this, "Please authorize Root or Shizuku to configure toggles.", android.widget.Toast.LENGTH_SHORT).show();
+                return true;
+            }
+            return false;
+        };
+        radioSimAuto.setOnTouchListener(lockTouch);
+        radioSim1.setOnTouchListener(lockTouch);
+        radioSim2.setOnTouchListener(lockTouch);
+
         targetSimRadioGroup.setOnCheckedChangeListener((group, checkedId) -> {
-			updateSeparatorVisibility();
+            if (updatingSimUi) return;
             TargetSim target = TargetSim.AUTO;
             if (checkedId == R.id.radioSim1) target = TargetSim.SIM_1;
             else if (checkedId == R.id.radioSim2) target = TargetSim.SIM_2;
+            
+            // Validate slot immediately
+            if (target != TargetSim.AUTO && checkSelfPermission(android.Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED) {
+                android.telephony.SubscriptionManager sm = getSystemService(android.telephony.SubscriptionManager.class);
+                if (sm != null) {
+                    boolean found = false;
+                    java.util.List<android.telephony.SubscriptionInfo> infos = sm.getActiveSubscriptionInfoList();
+                    if (infos != null) {
+                        for (android.telephony.SubscriptionInfo info : infos) {
+                            if (info.getSimSlotIndex() == target.getManualSlotIndex()) {
+                                found = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (!found) {
+                        Toast.makeText(MainActivity.this, "No SIM card found in slot " + (target.getManualSlotIndex() + 1), Toast.LENGTH_SHORT).show();
+                        updatingSimUi = true;
+                        radioSimAuto.setChecked(true);
+                        updatingSimUi = false;
+                        target = TargetSim.AUTO;
+                    }
+                }
+            }
+            
+            updateSeparatorVisibility();
             appPreferences.onTargetSimChanged(target);
             updateAutoSimWarning();
+            updateCapabilities();
         });
     }
 
@@ -223,11 +318,125 @@ public class MainActivity extends Activity {
     protected void onResume() {
         super.onResume();
         if (appPreferences != null) updateAutoSimWarning();
+        checkAndRequestPermission();
+        updateErrorBanner();
+        updateCapabilities();
+    }
+
+    private void checkAndRequestPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            boolean granted = checkSelfPermission(android.Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED;
+            if (!granted) {
+                boolean shouldShowRationale = shouldShowRequestPermissionRationale(android.Manifest.permission.READ_PHONE_STATE);
+                if (shouldShowRationale) {
+                    showPermissionBottomSheet();
+                } else {
+                    // Automatically prompt on first open if not asked yet
+                    requestPermissions(new String[]{android.Manifest.permission.READ_PHONE_STATE}, REQ_CODE_PHONE_STATE);
+                }
+            } else if (permissionDialog != null && permissionDialog.isShowing()) {
+                permissionDialog.dismiss();
+            }
+        }
+    }
+
+    private void showPermissionBottomSheet() {
+        if (permissionDialog == null) {
+            permissionDialog = new Dialog(this, R.style.TransparentBottomSheetStyle);
+            View view = getLayoutInflater().inflate(R.layout.bottom_sheet_permission, null);
+            
+            view.findViewById(R.id.btnDismissPermission).setOnClickListener(v -> permissionDialog.dismiss());
+            view.findViewById(R.id.btnGrantPermission).setOnClickListener(v -> {
+                permissionDialog.dismiss();
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    requestPermissions(new String[]{android.Manifest.permission.READ_PHONE_STATE}, REQ_CODE_PHONE_STATE);
+                }
+            });
+            
+            permissionDialog.setContentView(view);
+            Window window = permissionDialog.getWindow();
+            if (window != null) {
+                window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+                window.setGravity(Gravity.BOTTOM);
+                window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+            }
+        }
+        
+        if (!permissionDialog.isShowing() && !activityDestroyed) {
+            permissionDialog.show();
+        }
+    }
+
+    private void updateErrorBanner() {
+        if (errorBannerContainer != null && appPreferences != null) {
+            DiagnosticError error = appPreferences.getLastError();
+            errorBannerContainer.setVisibility(error != null ? View.VISIBLE : View.GONE);
+        }
+    }
+
+    private void showDiagnosticDialog() {
+        if (isFinishing() || activityDestroyed) return;
+        
+        if (diagnosticDialog != null && diagnosticDialog.isShowing()) {
+            diagnosticDialog.dismiss(); appPreferences.clearLastError(); updateErrorBanner();
+        }
+
+        diagnosticDialog = new Dialog(this);
+        diagnosticDialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
+        diagnosticDialog.setContentView(R.layout.dialog_diagnostic);
+        diagnosticDialog.getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+        diagnosticDialog.getWindow().setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+
+        TextView reportText = diagnosticDialog.findViewById(R.id.diagnosticReportText);
+        if (reportText != null) {
+            String report = DiagnosticReporter.generateReport(appPreferences, new SimResolver(this, appPreferences));
+            reportText.setText(report);
+        }
+
+        View btnClose = diagnosticDialog.findViewById(R.id.btnCloseDiagnostic);
+        if (btnClose != null) btnClose.setOnClickListener(v -> { diagnosticDialog.dismiss(); appPreferences.clearLastError(); updateErrorBanner(); });
+
+        View btnCopy = diagnosticDialog.findViewById(R.id.btnCopyDiagnostic);
+        if (btnCopy != null) {
+            btnCopy.setOnClickListener(v -> {
+                ClipboardManager clipboard = (ClipboardManager) getSystemService(CLIPBOARD_SERVICE);
+                ClipData clip = ClipData.newPlainText("Diagnostic Report", reportText.getText());
+                clipboard.setPrimaryClip(clip);
+                Toast.makeText(this, "Report copied to clipboard", Toast.LENGTH_SHORT).show();
+            });
+        }
+
+        diagnosticDialog.show();
+    }
+
+    private void updateCapabilities() {
+        new Thread(() -> {
+            AppPreferences.NetworkCapabilities caps = capabilityResolver.getCapabilities(appPreferences.getExecutionMode());
+            runOnUiThread(() -> {
+                if (!activityDestroyed && tileCycleUiController != null) {
+                    tileCycleUiController.applyCapabilities(caps);
+                }
+            });
+        }).start();
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        if (requestCode == REQ_CODE_PHONE_STATE) {
+            if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                if (permissionDialog != null && permissionDialog.isShowing()) permissionDialog.dismiss();
+                updateCapabilities(); // Fetch capabilities immediately upon grant
+            } else {
+                showPermissionBottomSheet();
+            }
+        }
     }
 
     @Override
     protected void onDestroy() {
         activityDestroyed = true;
+        if (appPreferences != null) appPreferences.unregisterListener(this);
         Shizuku.removeBinderReceivedListener(binderReceivedListener);
         Shizuku.removeBinderDeadListener(binderDeadListener);
         Shizuku.removeRequestPermissionResultListener(permissionResultListener);
@@ -241,6 +450,13 @@ public class MainActivity extends Activity {
             rootCheckThread = null;
         }
         super.onDestroy();
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(android.content.SharedPreferences sharedPreferences, String key) {
+        if ("last_error_cmd".equals(key)) {
+            runOnUiThread(() -> updateErrorBanner());
+        }
     }
 
     private void checkRootPermission() {
@@ -263,8 +479,14 @@ public class MainActivity extends Activity {
             runOnUiThread(() -> {
                 if (activityDestroyed || appPreferences == null
                         || appPreferences.getExecutionMode() != ExecutionMode.ROOT) return;
-                if (finalGranted) setStatus("Root mode active & authorized!", 0xFF1B873F);
-                else setStatus("Root permission denied or unavailable.", 0xFFFF5555);
+                if (finalGranted) {
+                    setStatus("Root mode active & authorized!", 0xFF1B873F);
+                    appPreferences.setTileErrorState(com.dhangofa.networktoggle.config.AppPreferences.TILE_ERROR_NONE);
+                } else {
+                    setStatus("Root permission denied or unavailable.", 0xFFFF5555);
+                    appPreferences.setTileErrorState(com.dhangofa.networktoggle.config.AppPreferences.TILE_ERROR_ROOT);
+                }
+                android.service.quicksettings.TileService.requestListeningState(MainActivity.this, new android.content.ComponentName(MainActivity.this, NetworkTileService.class));
             });
         });
         rootCheckThread.start();
@@ -275,19 +497,35 @@ public class MainActivity extends Activity {
         try {
             if (!Shizuku.pingBinder()) {
                 setStatus("Shizuku is not running.", 0xFFFF5555);
+                if (appPreferences != null) {
+                    appPreferences.setTileErrorState(com.dhangofa.networktoggle.config.AppPreferences.TILE_ERROR_SHIZUKU);
+                    android.service.quicksettings.TileService.requestListeningState(MainActivity.this, new android.content.ComponentName(MainActivity.this, NetworkTileService.class));
+                }
                 return;
             }
             if (Shizuku.checkSelfPermission() == PackageManager.PERMISSION_GRANTED) {
                 setStatus("Shizuku mode active & authorized!", 0xFF1B873F);
+                if (appPreferences != null) {
+                    appPreferences.setTileErrorState(com.dhangofa.networktoggle.config.AppPreferences.TILE_ERROR_NONE);
+                    android.service.quicksettings.TileService.requestListeningState(MainActivity.this, new android.content.ComponentName(MainActivity.this, NetworkTileService.class));
+                }
                 return;
             }
             setStatus("Shizuku permission not granted.", 0xFFFFB300);
+            if (appPreferences != null) {
+                appPreferences.setTileErrorState(com.dhangofa.networktoggle.config.AppPreferences.TILE_ERROR_SHIZUKU);
+                android.service.quicksettings.TileService.requestListeningState(MainActivity.this, new android.content.ComponentName(MainActivity.this, NetworkTileService.class));
+            }
             if (requestIfNeeded) {
                 setStatus("Requesting Shizuku permission...", 0xFFFFB300);
                 Shizuku.requestPermission(0);
             }
         } catch (Exception e) {
             setStatus("Shizuku check failed.", 0xFFFF5555);
+            if (appPreferences != null) {
+                appPreferences.setTileErrorState(com.dhangofa.networktoggle.config.AppPreferences.TILE_ERROR_SHIZUKU);
+                android.service.quicksettings.TileService.requestListeningState(MainActivity.this, new android.content.ComponentName(MainActivity.this, NetworkTileService.class));
+            }
         }
     }
 
@@ -307,6 +545,32 @@ public class MainActivity extends Activity {
 	        statusText.setBackgroundResource(
 	                R.drawable.shape_pill_badge_bg
 	        );
+	    }
+	    updateAuthorizationUI(color == 0xFF1B873F);
+	}
+	
+	private boolean isUIAuthorized = true;
+	private void updateAuthorizationUI(boolean authorized) {
+	    if (isUIAuthorized == authorized) return;
+	    isUIAuthorized = authorized;
+	    
+	    float alpha = authorized ? 1.0f : 0.4f;
+	    View targetSimCard = findViewById(R.id.targetSimRadioGroup);
+	    if (targetSimCard != null) targetSimCard.setAlpha(alpha);
+	    View targetSimHeader = findViewById(R.id.targetSimHeaderContainer);
+	    if (targetSimHeader != null) targetSimHeader.setAlpha(alpha);
+	    View autoSimWarningText = findViewById(R.id.autoSimWarningText);
+	    if (autoSimWarningText != null) autoSimWarningText.setAlpha(alpha);
+	    
+	    if (tileCycleUiController != null) {
+	        tileCycleUiController.setAuthorized(authorized);
+	    }
+	    
+	    if (authorized && appPreferences != null) {
+	        appPreferences.clearDeviceCapabilities();
+	        appPreferences.invalidateSlotCache(0);
+	        appPreferences.invalidateSlotCache(1);
+	        updateCapabilities();
 	    }
 	}
 

--- a/app/src/main/java/com/dhangofa/networktoggle/NetworkTileService.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/NetworkTileService.java
@@ -35,6 +35,8 @@ public class NetworkTileService extends TileService {
     private static Icon icon5g;
     private static Icon iconP5g;
     private static Icon iconP4g;
+    private static Icon iconP3g;
+    private static Icon icon2g;
     private static Icon iconUnknown;
 
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
@@ -42,14 +44,14 @@ public class NetworkTileService extends TileService {
     private AppPreferences appPreferences;
     private NetworkModeReader networkModeReader;
     private NetworkModeController networkModeController;
-	  private TileCycleManager tileCycleManager;
+    private TileCycleManager tileCycleManager;
 
     @Override
     public void onCreate() {
         super.onCreate();
 
         appPreferences = new AppPreferences(this);
-    		tileCycleManager = new TileCycleManager(appPreferences);
+        tileCycleManager = new TileCycleManager(appPreferences);
         SimResolver simResolver = new SimResolver(appPreferences);
         networkModeReader = new NetworkModeReader(appPreferences, simResolver);
         networkModeController = new NetworkModeController(simResolver);
@@ -67,25 +69,25 @@ public class NetworkTileService extends TileService {
             return;
         }
 
-      EXECUTOR.execute(() -> {
-        NetworkMode realMode = networkModeReader.readCurrentMode();
+        EXECUTOR.execute(() -> {
+            NetworkMode realMode = networkModeReader.readCurrentMode();
 
-        mainHandler.post(() -> {
-          /*
-           * A tile click or another operation may have updated the state
-           * while this asynchronous readback was running.
-           */
-          if (appPreferences.getCachedNetworkMode()
-              != NetworkMode.UNKNOWN) {
-            return;
-          }
+            mainHandler.post(() -> {
+                /*
+                 * A tile click or another operation may have updated the state
+                 * while this asynchronous readback was running.
+                 */
+                if (appPreferences.getCachedNetworkMode()
+                        != NetworkMode.UNKNOWN) {
+                    return;
+                }
 
-          if (realMode != NetworkMode.UNKNOWN) {
-            appPreferences.setCachedNetworkMode(realMode);
-            updateTileUI(realMode);
-          }
+                if (realMode != NetworkMode.UNKNOWN) {
+                    appPreferences.setCachedNetworkMode(realMode);
+                    updateTileUI(realMode);
+                }
+            });
         });
-      });
     }
 
     @Override
@@ -177,6 +179,12 @@ public class NetworkTileService extends TileService {
             case "P4G":
                 if (iconP4g == null) iconP4g = createTextOnlyIcon("P4G");
                 return iconP4g;
+            case "P3G":
+                if (iconP3g == null) iconP3g = createTextOnlyIcon("P3G");
+                return iconP3g;
+            case "2G":
+                if (icon2g == null) icon2g = createTextOnlyIcon("2G");
+                return icon2g;
             default:
                 if (iconUnknown == null) {
                     iconUnknown = createTextOnlyIcon("?");

--- a/app/src/main/java/com/dhangofa/networktoggle/NetworkTileService.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/NetworkTileService.java
@@ -1,4 +1,5 @@
 package com.dhangofa.networktoggle;
+import android.os.Build;
 
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
@@ -10,6 +11,10 @@ import android.os.Handler;
 import android.os.Looper;
 import android.service.quicksettings.Tile;
 import android.service.quicksettings.TileService;
+import android.content.Intent;
+import android.app.PendingIntent;
+import rikka.shizuku.Shizuku;
+import android.content.pm.PackageManager;
 import android.widget.Toast;
 
 import com.dhangofa.networktoggle.config.AppPreferences;
@@ -45,21 +50,40 @@ public class NetworkTileService extends TileService {
     private NetworkModeReader networkModeReader;
     private NetworkModeController networkModeController;
     private TileCycleManager tileCycleManager;
+    private com.dhangofa.networktoggle.telephony.SimResolver simResolver;
 
     @Override
     public void onCreate() {
         super.onCreate();
 
+        // Init dependencies
         appPreferences = new AppPreferences(this);
         tileCycleManager = new TileCycleManager(appPreferences);
-        SimResolver simResolver = new SimResolver(appPreferences);
-        networkModeReader = new NetworkModeReader(appPreferences, simResolver);
+        simResolver = new com.dhangofa.networktoggle.telephony.SimResolver(this, appPreferences);
+        networkModeReader = new com.dhangofa.networktoggle.telephony.NetworkModeReader(this, appPreferences, simResolver);
         networkModeController = new NetworkModeController(simResolver);
     }
 
     @Override
     public void onStartListening() {
         super.onStartListening();
+        
+        // Passive Shizuku Check
+        if (appPreferences.getExecutionMode() == ExecutionMode.SHIZUKU) {
+            boolean isShizukuOk = false;
+            try {
+                isShizukuOk = rikka.shizuku.Shizuku.pingBinder() && rikka.shizuku.Shizuku.checkSelfPermission() == android.content.pm.PackageManager.PERMISSION_GRANTED;
+            } catch (Throwable t) {
+                isShizukuOk = false;
+            }
+        
+            int currentError = appPreferences.getTileErrorState();
+            if (!isShizukuOk && currentError != AppPreferences.TILE_ERROR_SHIZUKU) {
+                appPreferences.setTileErrorState(AppPreferences.TILE_ERROR_SHIZUKU);
+            } else if (isShizukuOk && currentError == AppPreferences.TILE_ERROR_SHIZUKU) {
+                appPreferences.setTileErrorState(AppPreferences.TILE_ERROR_NONE);
+            }
+        }
 
         NetworkMode cachedMode = appPreferences.getCachedNetworkMode();
         updateTileUI(cachedMode);
@@ -111,27 +135,70 @@ public class NetworkTileService extends TileService {
         updateTileSwitchingUI();
 
         EXECUTOR.execute(() -> {
+            int slotIndex = simResolver.resolveTargetSlotIndex(executionMode);
+            if (!simResolver.isValidSlotIndex(slotIndex)) {
+                mainHandler.post(() -> {
+                    Toast.makeText(getApplicationContext(), "No SIM card found in target slot.", Toast.LENGTH_SHORT).show();
+                    appPreferences.onTargetSimChanged(com.dhangofa.networktoggle.model.TargetSim.AUTO);
+                    updateTileUI(appPreferences.getCachedNetworkMode());
+                    IS_SWITCHING.set(false);
+                });
+                return;
+            }
+
             CommandResult result = networkModeController.apply(
                     nextMode,
                     executionMode
             );
 
-            mainHandler.post(() -> {
-                try {
-                    if (result.isSuccess()) {
-                        appPreferences.setCachedNetworkMode(nextMode);
-                        appPreferences.setAutoSimError(false);
-                        updateTileUI(nextMode);
-                    } else {
-                        updateTileUI(currentMode);
-                        if (appPreferences.hasAutoSimError()) {
-                            showAutoSimErrorToast();
-                        }
-                    }
-                } finally {
+            if (result.isSuccess()) {
+                appPreferences.setCachedNetworkMode(nextMode);
+                appPreferences.setAutoSimError(false);
+                appPreferences.setTileErrorState(AppPreferences.TILE_ERROR_NONE);
+                mainHandler.post(() -> {
+                    updateTileUI(nextMode);
                     IS_SWITCHING.set(false);
+                });
+            } else {
+                // Command failed! Check for permission failures first.
+                boolean isAuthError = false;
+                if (executionMode == ExecutionMode.SHIZUKU) {
+                    try {
+                        if (!Shizuku.pingBinder() || Shizuku.checkSelfPermission() != PackageManager.PERMISSION_GRANTED) {
+                            isAuthError = true;
+                            appPreferences.setTileErrorState(AppPreferences.TILE_ERROR_SHIZUKU);
+                        }
+                    } catch (Throwable t) {
+                        isAuthError = true;
+                        appPreferences.setTileErrorState(AppPreferences.TILE_ERROR_SHIZUKU);
+                    }
+                } else if (executionMode == ExecutionMode.ROOT) {
+                    try {
+                        Process p = Runtime.getRuntime().exec(new String[]{"su", "-c", "true"});
+                        int exitCode = p.waitFor();
+                        if (exitCode != 0) {
+                            isAuthError = true;
+                            appPreferences.setTileErrorState(AppPreferences.TILE_ERROR_ROOT);
+                        }
+                    } catch (Exception e) {
+                        isAuthError = true;
+                        appPreferences.setTileErrorState(AppPreferences.TILE_ERROR_ROOT);
+                    }
                 }
-            });
+
+                if (!isAuthError) {
+                    appPreferences.setTileErrorState(AppPreferences.TILE_ERROR_CMD);
+                    appPreferences.setLastError(result.getCommand(), result.getStderr());
+                }
+
+                mainHandler.post(() -> {
+                    updateTileUI(currentMode);
+                    if (appPreferences.hasAutoSimError()) {
+                        showAutoSimErrorToast();
+                    }
+                    IS_SWITCHING.set(false);
+                });
+            }
         });
     }
 
@@ -210,6 +277,27 @@ public class NetworkTileService extends TileService {
             return;
         }
 
+        int errorState = appPreferences.getTileErrorState();
+        if (errorState == AppPreferences.TILE_ERROR_SHIZUKU) {
+            tile.setState(Tile.STATE_UNAVAILABLE);
+            tile.setLabel("Shizuku Unavailable");
+            tile.setIcon(getCachedIcon("?"));
+            tile.updateTile();
+            return;
+        } else if (errorState == AppPreferences.TILE_ERROR_ROOT) {
+            tile.setState(Tile.STATE_UNAVAILABLE);
+            tile.setLabel("Root Unavailable");
+            tile.setIcon(getCachedIcon("?"));
+            tile.updateTile();
+            return;
+        } else if (errorState == AppPreferences.TILE_ERROR_CMD) {
+            tile.setState(Tile.STATE_INACTIVE);
+            tile.setLabel("Error Check App");
+            tile.setIcon(getCachedIcon("?"));
+            tile.updateTile();
+            return;
+        }
+
         if (mode == NetworkMode.UNKNOWN) {
             if (appPreferences.getExecutionMode() == ExecutionMode.NONE) {
                 tile.setState(Tile.STATE_UNAVAILABLE);
@@ -230,6 +318,8 @@ public class NetworkTileService extends TileService {
 
         tile.updateTile();
     }
+
+
 
     private void showAutoSimErrorToast() {
         Toast.makeText(

--- a/app/src/main/java/com/dhangofa/networktoggle/config/AppPreferences.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/config/AppPreferences.java
@@ -17,6 +17,11 @@ public final class AppPreferences {
     private static final String KEY_NETWORK_STATE = "net_state";
     private static final String KEY_AUTO_SIM_ERROR = "auto_sim_error";
     private static final String KEY_TILE_CYCLE_MODES = "tile_cycle_modes";
+    
+    // New keys for capabilities caching
+    private static final String KEY_DEVICE_CAPS_PREFIX = "device_cap_";
+    private static final String KEY_SLOT_SUBID_PREFIX = "slot_subid_";
+    private static final String KEY_SLOT_CAPS_PREFIX = "slot_cap_";
 
     private final SharedPreferences preferences;
 
@@ -101,6 +106,84 @@ public final class AppPreferences {
         preferences.edit()
                 .putInt(KEY_NETWORK_STATE, NetworkMode.UNKNOWN.getStateValue())
                 .putBoolean(KEY_AUTO_SIM_ERROR, false)
+                .apply();
+    }
+
+    // --- CAPABILITY CACHING LOGIC ---
+
+    public static class NetworkCapabilities {
+        public final boolean supports2g;
+        public final boolean supports3g;
+        public final boolean supports4g;
+        public final boolean supports5g;
+
+        public NetworkCapabilities(boolean supports2g, boolean supports3g, boolean supports4g, boolean supports5g) {
+            this.supports2g = supports2g;
+            this.supports3g = supports3g;
+            this.supports4g = supports4g;
+            this.supports5g = supports5g;
+        }
+
+        // Failsafe fallback: Assume everything is supported if we can't fetch it
+        public static NetworkCapabilities assumeAll() {
+            return new NetworkCapabilities(true, true, true, true);
+        }
+    }
+
+    public void saveDeviceCapabilities(NetworkCapabilities caps) {
+        preferences.edit()
+                .putBoolean(KEY_DEVICE_CAPS_PREFIX + "2g", caps.supports2g)
+                .putBoolean(KEY_DEVICE_CAPS_PREFIX + "3g", caps.supports3g)
+                .putBoolean(KEY_DEVICE_CAPS_PREFIX + "4g", caps.supports4g)
+                .putBoolean(KEY_DEVICE_CAPS_PREFIX + "5g", caps.supports5g)
+                .apply();
+    }
+
+    public NetworkCapabilities getDeviceCapabilities() {
+        if (!preferences.contains(KEY_DEVICE_CAPS_PREFIX + "5g")) {
+            return null; // Return null so the resolver knows it needs to fetch them
+        }
+        return new NetworkCapabilities(
+                preferences.getBoolean(KEY_DEVICE_CAPS_PREFIX + "2g", true),
+                preferences.getBoolean(KEY_DEVICE_CAPS_PREFIX + "3g", true),
+                preferences.getBoolean(KEY_DEVICE_CAPS_PREFIX + "4g", true),
+                preferences.getBoolean(KEY_DEVICE_CAPS_PREFIX + "5g", true)
+        );
+    }
+
+    public void saveSlotCapabilities(int slotIndex, int subId, NetworkCapabilities caps) {
+        preferences.edit()
+                .putInt(KEY_SLOT_SUBID_PREFIX + slotIndex, subId)
+                .putBoolean(KEY_SLOT_CAPS_PREFIX + slotIndex + "_2g", caps.supports2g)
+                .putBoolean(KEY_SLOT_CAPS_PREFIX + slotIndex + "_3g", caps.supports3g)
+                .putBoolean(KEY_SLOT_CAPS_PREFIX + slotIndex + "_4g", caps.supports4g)
+                .putBoolean(KEY_SLOT_CAPS_PREFIX + slotIndex + "_5g", caps.supports5g)
+                .apply();
+    }
+
+    public int getCachedSubIdForSlot(int slotIndex) {
+        return preferences.getInt(KEY_SLOT_SUBID_PREFIX + slotIndex, -1);
+    }
+
+    public NetworkCapabilities getSlotCapabilities(int slotIndex) {
+        if (!preferences.contains(KEY_SLOT_CAPS_PREFIX + slotIndex + "_5g")) {
+            return null;
+        }
+        return new NetworkCapabilities(
+                preferences.getBoolean(KEY_SLOT_CAPS_PREFIX + slotIndex + "_2g", true),
+                preferences.getBoolean(KEY_SLOT_CAPS_PREFIX + slotIndex + "_3g", true),
+                preferences.getBoolean(KEY_SLOT_CAPS_PREFIX + slotIndex + "_4g", true),
+                preferences.getBoolean(KEY_SLOT_CAPS_PREFIX + slotIndex + "_5g", true)
+        );
+    }
+    
+    public void invalidateSlotCache(int slotIndex) {
+        preferences.edit()
+                .remove(KEY_SLOT_SUBID_PREFIX + slotIndex)
+                .remove(KEY_SLOT_CAPS_PREFIX + slotIndex + "_2g")
+                .remove(KEY_SLOT_CAPS_PREFIX + slotIndex + "_3g")
+                .remove(KEY_SLOT_CAPS_PREFIX + slotIndex + "_4g")
+                .remove(KEY_SLOT_CAPS_PREFIX + slotIndex + "_5g")
                 .apply();
     }
 }

--- a/app/src/main/java/com/dhangofa/networktoggle/config/AppPreferences.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/config/AppPreferences.java
@@ -18,16 +18,42 @@ public final class AppPreferences {
     private static final String KEY_AUTO_SIM_ERROR = "auto_sim_error";
     private static final String KEY_TILE_CYCLE_MODES = "tile_cycle_modes";
     
-    // New keys for capabilities caching
+    private static final String KEY_LAST_ERROR_CMD = "last_error_cmd";
+    private static final String KEY_LAST_ERROR_STDERR = "last_error_stderr";
+    private static final String KEY_LAST_ERROR_TIMESTAMP = "last_error_time";
+    
+    // Keys for capabilities caching
     private static final String KEY_DEVICE_CAPS_PREFIX = "device_cap_";
     private static final String KEY_SLOT_SUBID_PREFIX = "slot_subid_";
     private static final String KEY_SLOT_CAPS_PREFIX = "slot_cap_";
+    
+    public static final int TILE_ERROR_NONE = 0;
+    public static final int TILE_ERROR_SHIZUKU = 1;
+    public static final int TILE_ERROR_ROOT = 2;
+    public static final int TILE_ERROR_CMD = 3;
+    private static final String KEY_TILE_ERROR = "tile_error_state";
 
     private final SharedPreferences preferences;
 
     public AppPreferences(Context context) {
         preferences = context.getApplicationContext()
                 .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+    }
+
+    public int getTileErrorState() {
+        return preferences.getInt(KEY_TILE_ERROR, TILE_ERROR_NONE);
+    }
+
+    public void setTileErrorState(int state) {
+        preferences.edit().putInt(KEY_TILE_ERROR, state).apply();
+    }
+
+    public void registerListener(SharedPreferences.OnSharedPreferenceChangeListener listener) {
+        preferences.registerOnSharedPreferenceChangeListener(listener);
+    }
+
+    public void unregisterListener(SharedPreferences.OnSharedPreferenceChangeListener listener) {
+        preferences.unregisterOnSharedPreferenceChangeListener(listener);
     }
 
     public ExecutionMode getExecutionMode() {
@@ -61,7 +87,36 @@ public final class AppPreferences {
         preferences.edit().putBoolean(KEY_AUTO_SIM_ERROR, hasError).apply();
     }
 
+    public void setLastError(String command, String stderr) {
+        preferences.edit()
+                .putString(KEY_LAST_ERROR_CMD, command)
+                .putString(KEY_LAST_ERROR_STDERR, stderr)
+                .putLong(KEY_LAST_ERROR_TIMESTAMP, System.currentTimeMillis())
+                .apply();
+    }
+
+    public com.dhangofa.networktoggle.model.DiagnosticError getLastError() {
+        String cmd = preferences.getString(KEY_LAST_ERROR_CMD, null);
+        String stderr = preferences.getString(KEY_LAST_ERROR_STDERR, null);
+        long time = preferences.getLong(KEY_LAST_ERROR_TIMESTAMP, 0);
+        
+        if (cmd == null && stderr == null) return null;
+        return new com.dhangofa.networktoggle.model.DiagnosticError(cmd, stderr, time);
+    }
+
+    public void clearLastError() {
+        if (getTileErrorState() == TILE_ERROR_CMD) {
+            setTileErrorState(TILE_ERROR_NONE);
+        }
+        preferences.edit()
+                .remove(KEY_LAST_ERROR_CMD)
+                .remove(KEY_LAST_ERROR_STDERR)
+                .remove(KEY_LAST_ERROR_TIMESTAMP)
+                .apply();
+    }
+
     public void onExecutionModeChanged(ExecutionMode mode) {
+        setTileErrorState(TILE_ERROR_NONE);
         preferences.edit()
                 .putInt(KEY_EXEC_MODE, mode.getValue())
                 .putInt(KEY_NETWORK_STATE, NetworkMode.UNKNOWN.getStateValue())
@@ -177,6 +232,15 @@ public final class AppPreferences {
         );
     }
     
+    public void clearDeviceCapabilities() {
+        preferences.edit()
+                .remove(KEY_DEVICE_CAPS_PREFIX + "2g")
+                .remove(KEY_DEVICE_CAPS_PREFIX + "3g")
+                .remove(KEY_DEVICE_CAPS_PREFIX + "4g")
+                .remove(KEY_DEVICE_CAPS_PREFIX + "5g")
+                .apply();
+    }
+
     public void invalidateSlotCache(int slotIndex) {
         preferences.edit()
                 .remove(KEY_SLOT_SUBID_PREFIX + slotIndex)

--- a/app/src/main/java/com/dhangofa/networktoggle/cycle/TileCycleManager.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/cycle/TileCycleManager.java
@@ -71,8 +71,37 @@ public final class TileCycleManager {
         }
 
         appPreferences.setTileCycleModes(cycle);
-        appPreferences.clearCachedNetworkMode();
+        // Cache is purposefully kept alive so UI changes can sync network state
         return ChangeResult.CHANGED;
+    }
+
+    public boolean forceRemoveUnsupportedAndAutoFill(AppPreferences.NetworkCapabilities caps) {
+        List<NetworkMode> cycle = getCycle();
+        boolean changed = false;
+
+        if (!caps.supports5g) { 
+            changed |= cycle.remove(NetworkMode.PREFERRED_5G); 
+            changed |= cycle.remove(NetworkMode.FIVE_G_ONLY); 
+        }
+        if (!caps.supports3g) { 
+            changed |= cycle.remove(NetworkMode.PREFERRED_3G); 
+        }
+        if (!caps.supports2g) { 
+            changed |= cycle.remove(NetworkMode.TWO_G_ONLY); 
+        }
+
+        if (changed) {
+            // Auto fill to reach MIN_MODES
+            if (cycle.size() < MIN_MODES) {
+                if (!cycle.contains(NetworkMode.PREFERRED_4G)) cycle.add(NetworkMode.PREFERRED_4G);
+                if (cycle.size() < MIN_MODES && caps.supports5g && !cycle.contains(NetworkMode.PREFERRED_5G)) cycle.add(NetworkMode.PREFERRED_5G);
+                if (cycle.size() < MIN_MODES && !cycle.contains(NetworkMode.FOUR_G_ONLY)) cycle.add(NetworkMode.FOUR_G_ONLY);
+            }
+            appPreferences.setTileCycleModes(cycle);
+            // Cache is purposefully kept alive so UI changes can sync network state
+            return true;
+        }
+        return false;
     }
 
     public boolean isValid(List<NetworkMode> cycle) {

--- a/app/src/main/java/com/dhangofa/networktoggle/model/DiagnosticError.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/model/DiagnosticError.java
@@ -1,0 +1,13 @@
+package com.dhangofa.networktoggle.model;
+
+public class DiagnosticError {
+    public final String command;
+    public final String stderr;
+    public final long timestamp;
+
+    public DiagnosticError(String command, String stderr, long timestamp) {
+        this.command = command;
+        this.stderr = stderr;
+        this.timestamp = timestamp;
+    }
+}

--- a/app/src/main/java/com/dhangofa/networktoggle/model/NetworkMode.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/model/NetworkMode.java
@@ -5,7 +5,9 @@ public enum NetworkMode {
     FOUR_G_ONLY(1, "4G Only", "4G Only", "4G", "1000000000000"),
     FIVE_G_ONLY(2, "5G Only", "5G Only", "5G", "10000000000000000000"),
     PREFERRED_5G(3, "Preferred 5G", "Pref 5G", "P5G", "11011111101111111111"),
-    PREFERRED_4G(4, "Preferred 4G", "Pref 4G", "P4G", "1001101001110000111");
+    PREFERRED_4G(4, "Preferred 4G", "Pref 4G", "P4G", "1001101001111110111"),
+    PREFERRED_3G(5, "Preferred 3G", "Pref 3G", "P3G", "1001100001111110111"),
+    TWO_G_ONLY(6, "2G Only", "2G Only", "2G", "1000000000000011");
 
     private final int stateValue;
     private final String displayName;
@@ -40,6 +42,8 @@ public enum NetworkMode {
             case FIVE_G_ONLY: return PREFERRED_5G;
             case PREFERRED_5G: return PREFERRED_4G;
             case PREFERRED_4G:
+            case PREFERRED_3G:
+            case TWO_G_ONLY:
             case UNKNOWN:
             default: return FOUR_G_ONLY;
         }
@@ -48,6 +52,21 @@ public enum NetworkMode {
     public static NetworkMode fromLegacyMode(Integer legacyMode) {
         if (legacyMode == null) return UNKNOWN;
         switch (legacyMode) {
+            case 1:
+            case 16:
+                return TWO_G_ONLY;
+            case 0:
+            case 2:
+            case 3:
+            case 4:
+            case 5:
+            case 6:
+            case 7:
+            case 13:
+            case 14:
+            case 18:
+            case 21: // Global 3G (CDMA+EVDO+GSM+WCDMA)
+                return PREFERRED_3G;
             case 11: return FOUR_G_ONLY;
             case 23: return FIVE_G_ONLY;
             case 33: return PREFERRED_5G;
@@ -59,7 +78,7 @@ public enum NetworkMode {
             case 17:
             case 19:
             case 20:
-            case 22:
+            case 22: // Global 4G (LTE+CDMA+EVDO+GSM+WCDMA)
                 return PREFERRED_4G;
             default:
                 if (legacyMode >= 24 && legacyMode <= 32) return PREFERRED_5G;

--- a/app/src/main/java/com/dhangofa/networktoggle/model/NetworkMode.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/model/NetworkMode.java
@@ -5,8 +5,8 @@ public enum NetworkMode {
     FOUR_G_ONLY(1, "4G Only", "4G Only", "4G", "1000000000000"),
     FIVE_G_ONLY(2, "5G Only", "5G Only", "5G", "10000000000000000000"),
     PREFERRED_5G(3, "Preferred 5G", "Pref 5G", "P5G", "11011111101111111111"),
-    PREFERRED_4G(4, "Preferred 4G", "Pref 4G", "P4G", "1001101001111110111"),
-    PREFERRED_3G(5, "Preferred 3G", "Pref 3G", "P3G", "1001100001111110111"),
+    PREFERRED_4G(4, "Preferred 4G", "Pref 4G", "P4G", "1011111101111111111"),
+    PREFERRED_3G(5, "Preferred 3G", "Pref 3G", "P3G", "11110101111111111"),
     TWO_G_ONLY(6, "2G Only", "2G Only", "2G", "1000000000000011");
 
     private final int stateValue;

--- a/app/src/main/java/com/dhangofa/networktoggle/telephony/LteAndAboveCarrierRegistry.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/telephony/LteAndAboveCarrierRegistry.java
@@ -4,16 +4,46 @@ import java.util.Arrays;
 import java.util.List;
 
 public final class LteAndAboveCarrierRegistry {
-    
+
     // REGION: INDIA
-    // Jio is purely 4G/5G. It has no 2G/3G infrastructure.
     private static final List<String> INDIA_LTE_AND_ABOVE = Arrays.asList(
             "jio", "ind-jio", "jio 4g", "jio true5g"
     );
 
-    // REGION: USA (Examples)
+    // REGION: USA
+    // Verizon, AT&T, and T-Mobile have fully shut down 2G/3G networks as of 2026. Dish is 5G only.
     private static final List<String> USA_LTE_AND_ABOVE = Arrays.asList(
-            "verizon", "vzw"
+            "verizon", "vzw", "at&t", "att", "t-mobile", "tmobile", "dish", "dish wireless"
+    );
+
+    // REGION: JAPAN
+    // Docomo, KDDI (au), SoftBank, and Rakuten have shut down their 3G networks.
+    private static final List<String> JAPAN_LTE_AND_ABOVE = Arrays.asList(
+            "docomo", "ntt docomo", "au", "kddi", "softbank", "rakuten", "rakuten mobile"
+    );
+
+    // REGION: AUSTRALIA
+    // Telstra, Optus, and Vodafone Australia (TPG) have fully shut down 3G.
+    private static final List<String> AUSTRALIA_LTE_AND_ABOVE = Arrays.asList(
+            "telstra", "optus", "vodafone au", "vodafone australia", "tpg"
+    );
+
+    // REGION: TAIWAN
+    // Chunghwa Telecom, Taiwan Mobile, and Far EasTone fully shut down 3G in mid-2024.
+    private static final List<String> TAIWAN_LTE_AND_ABOVE = Arrays.asList(
+            "chunghwa", "chunghwa telecom", "taiwan mobile", "far eastone", "fet"
+    );
+
+    // REGION: SINGAPORE
+    // Singtel, StarHub, and M1 fully shut down 3G in 2024.
+    private static final List<String> SINGAPORE_LTE_AND_ABOVE = Arrays.asList(
+            "singtel", "starhub", "m1"
+    );
+
+    // REGION: SOUTH KOREA
+    // LG U+ never had 3G and shut down 2G. (SK Telecom and KT still operate 3G as of 2026).
+    private static final List<String> SOUTHKOREA_LTE_AND_ABOVE = Arrays.asList(
+            "lg u+", "lgu+", "lg uplus", "uplus"
     );
 
     private LteAndAboveCarrierRegistry() {
@@ -35,6 +65,26 @@ public final class LteAndAboveCarrierRegistry {
         }
         
         for (String name : USA_LTE_AND_ABOVE) {
+            if (normalized.equals(name) || normalized.contains(name)) return true;
+        }
+
+        for (String name : JAPAN_LTE_AND_ABOVE) {
+            if (normalized.equals(name) || normalized.contains(name)) return true;
+        }
+
+        for (String name : AUSTRALIA_LTE_AND_ABOVE) {
+            if (normalized.equals(name) || normalized.contains(name)) return true;
+        }
+
+        for (String name : TAIWAN_LTE_AND_ABOVE) {
+            if (normalized.equals(name) || normalized.contains(name)) return true;
+        }
+
+        for (String name : SINGAPORE_LTE_AND_ABOVE) {
+            if (normalized.equals(name) || normalized.contains(name)) return true;
+        }
+
+        for (String name : SOUTHKOREA_LTE_AND_ABOVE) {
             if (normalized.equals(name) || normalized.contains(name)) return true;
         }
 

--- a/app/src/main/java/com/dhangofa/networktoggle/telephony/LteAndAboveCarrierRegistry.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/telephony/LteAndAboveCarrierRegistry.java
@@ -1,0 +1,43 @@
+package com.dhangofa.networktoggle.telephony;
+
+import java.util.Arrays;
+import java.util.List;
+
+public final class LteAndAboveCarrierRegistry {
+    
+    // REGION: INDIA
+    // Jio is purely 4G/5G. It has no 2G/3G infrastructure.
+    private static final List<String> INDIA_LTE_AND_ABOVE = Arrays.asList(
+            "jio", "ind-jio", "jio 4g", "jio true5g"
+    );
+
+    // REGION: USA (Examples)
+    private static final List<String> USA_LTE_AND_ABOVE = Arrays.asList(
+            "verizon", "vzw"
+    );
+
+    private LteAndAboveCarrierRegistry() {
+        // Private constructor
+    }
+
+    /**
+     * Stage 4: Checks if the carrier name belongs to a known LTE/5G only network.
+     */
+    public static boolean isLteAndAboveOnly(String carrierName) {
+        if (carrierName == null || carrierName.trim().isEmpty()) {
+            return false;
+        }
+        
+        String normalized = carrierName.toLowerCase().trim();
+
+        for (String name : INDIA_LTE_AND_ABOVE) {
+            if (normalized.equals(name) || normalized.contains(name)) return true;
+        }
+        
+        for (String name : USA_LTE_AND_ABOVE) {
+            if (normalized.equals(name) || normalized.contains(name)) return true;
+        }
+
+        return false;
+    }
+}

--- a/app/src/main/java/com/dhangofa/networktoggle/telephony/NetworkCapabilityResolver.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/telephony/NetworkCapabilityResolver.java
@@ -1,0 +1,137 @@
+package com.dhangofa.networktoggle.telephony;
+
+import android.os.Build;
+
+import com.dhangofa.networktoggle.command.CommandExecutor;
+import com.dhangofa.networktoggle.command.CommandExecutorFactory;
+import com.dhangofa.networktoggle.config.AppPreferences;
+import com.dhangofa.networktoggle.config.AppPreferences.NetworkCapabilities;
+import com.dhangofa.networktoggle.model.CommandResult;
+import com.dhangofa.networktoggle.model.ExecutionMode;
+
+public final class NetworkCapabilityResolver {
+    private final AppPreferences appPreferences;
+    private final SimResolver simResolver;
+
+    public NetworkCapabilityResolver(AppPreferences appPreferences, SimResolver simResolver) {
+        this.appPreferences = appPreferences;
+        this.simResolver = simResolver;
+    }
+
+    public NetworkCapabilities getCapabilities(ExecutionMode mode) {
+        if (mode == ExecutionMode.NONE) return NetworkCapabilities.assumeAll();
+
+        // ONE SINGLE CALL to get slotIndex, subId, and carrierName!
+        SimResolver.SimInfo simInfo = simResolver.resolveTargetSimInfo(mode);
+
+        if (simInfo == null || !simResolver.isValidSlotIndex(simInfo.slotIndex) || !simResolver.isValidSubId(simInfo.subId)) {
+            return NetworkCapabilities.assumeAll();
+        }
+
+        int slotIndex = simInfo.slotIndex;
+        int subId = simInfo.subId;
+        String carrierName = simInfo.carrierName;
+
+        // Check Cache
+        int cachedSubId = appPreferences.getCachedSubIdForSlot(slotIndex);
+        NetworkCapabilities cachedCaps = appPreferences.getSlotCapabilities(slotIndex);
+
+        if (cachedSubId == subId && cachedCaps != null) return cachedCaps;
+
+        // Invalidate cache and fetch
+        appPreferences.invalidateSlotCache(slotIndex);
+        
+        // Stage 1 & 2: Global Device/OS Capabilities
+        NetworkCapabilities deviceCaps = fetchDeviceCapabilities(mode);
+        
+        // Stage 3 & 4: Slot-Specific Carrier Capabilities (Pass carrierName directly)
+        NetworkCapabilities carrierCaps = fetchCarrierCapabilities(mode, slotIndex, carrierName);
+
+        // Combine
+        NetworkCapabilities finalCaps = new NetworkCapabilities(
+                deviceCaps.supports2g && carrierCaps.supports2g,
+                deviceCaps.supports3g && carrierCaps.supports3g,
+                deviceCaps.supports4g && carrierCaps.supports4g,
+                deviceCaps.supports5g && carrierCaps.supports5g
+        );
+
+        appPreferences.saveSlotCapabilities(slotIndex, subId, finalCaps);
+        return finalCaps;
+    }
+
+    private NetworkCapabilities fetchDeviceCapabilities(ExecutionMode mode) {
+        NetworkCapabilities cachedDevice = appPreferences.getDeviceCapabilities();
+        if (cachedDevice != null) return cachedDevice;
+
+        boolean supports5g = false;
+
+        // Stage 1: Android Version Check (Android 11 / API 30+)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            CommandExecutor executor = CommandExecutorFactory.forMode(mode);
+            if (executor != null) {
+                // Stage 2: Hardware Ceiling Check
+                CommandResult result = executor.execute("getprop ro.telephony.default_network");
+                if (result.isSuccess() && !result.getStdout().trim().isEmpty()) {
+                    String[] values = result.getStdout().trim().split(",");
+                    
+                    // Check if ANY value globally supports 5G (>= 23)
+                    for (String val : values) {
+                        Integer parsed = ShellValueParser.extractFirstInt(val);
+                        if (parsed != null && parsed >= 23) {
+                            supports5g = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        NetworkCapabilities deviceCaps = new NetworkCapabilities(true, true, true, supports5g);
+        appPreferences.saveDeviceCapabilities(deviceCaps);
+        return deviceCaps;
+    }
+
+    private NetworkCapabilities fetchCarrierCapabilities(ExecutionMode mode, int slotIndex, String carrierName) {
+        CommandExecutor executor = CommandExecutorFactory.forMode(mode);
+        if (executor == null) return NetworkCapabilities.assumeAll();
+
+        // Stage 3: Carrier Config XML Verification
+        String command = "dumpsys carrier_config | grep -E 'Phone Id|hide_enable_2g_bool|carrier_supports_2g_bool|hide_enable_3g_bool|carrier_supports_3g_bool|carrier_nr_availabilities_int_array'";
+        CommandResult result = executor.execute(command);
+        
+        boolean supports2g = true;
+        boolean supports3g = true;
+        boolean supports5g = true;
+
+        if (result.isSuccess() && !result.getStdout().trim().isEmpty()) {
+            String[] lines = result.getStdout().split("\\n");
+            boolean inTargetSlot = false;
+
+            for (String line : lines) {
+                String trimmed = line.trim();
+                if (trimmed.startsWith("Phone Id =")) {
+                    Integer currentSlot = ShellValueParser.extractFirstInt(trimmed);
+                    inTargetSlot = (currentSlot != null && currentSlot == slotIndex);
+                } else if (inTargetSlot) {
+                    if (trimmed.contains("hide_enable_2g_bool = true") || trimmed.contains("carrier_supports_2g_bool = false")) {
+                        supports2g = false;
+                    }
+                    if (trimmed.contains("hide_enable_3g_bool = true") || trimmed.contains("carrier_supports_3g_bool = false")) {
+                        supports3g = false;
+                    }
+                    if (trimmed.startsWith("carrier_nr_availabilities_int_array = []")) {
+                        supports5g = false;
+                    }
+                }
+            }
+        }
+
+        // Stage 4: Smart Blocklist Check
+        if (LteAndAboveCarrierRegistry.isLteAndAboveOnly(carrierName)) {
+            supports2g = false;
+            supports3g = false;
+        }
+
+        return new NetworkCapabilities(supports2g, supports3g, true, supports5g);
+    }
+}

--- a/app/src/main/java/com/dhangofa/networktoggle/telephony/NetworkCapabilityResolver.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/telephony/NetworkCapabilityResolver.java
@@ -36,7 +36,12 @@ public final class NetworkCapabilityResolver {
         int cachedSubId = appPreferences.getCachedSubIdForSlot(slotIndex);
         NetworkCapabilities cachedCaps = appPreferences.getSlotCapabilities(slotIndex);
 
-        if (cachedSubId == subId && cachedCaps != null) return cachedCaps;
+        if (cachedSubId == subId && cachedCaps != null) {
+            if (LteAndAboveCarrierRegistry.isLteAndAboveOnly(carrierName)) {
+                return new NetworkCapabilities(false, false, cachedCaps.supports4g, cachedCaps.supports5g);
+            }
+            return cachedCaps;
+        }
 
         // Invalidate cache and fetch
         appPreferences.invalidateSlotCache(slotIndex);
@@ -55,7 +60,13 @@ public final class NetworkCapabilityResolver {
                 deviceCaps.supports5g && carrierCaps.supports5g
         );
 
-        appPreferences.saveSlotCapabilities(slotIndex, subId, finalCaps);
+        CommandExecutor executor = CommandExecutorFactory.forMode(mode);
+        if (executor != null) {
+             CommandResult pingResult = executor.execute("echo test");
+             if (pingResult.isSuccess()) {
+                 appPreferences.saveSlotCapabilities(slotIndex, subId, finalCaps);
+             }
+        }
         return finalCaps;
     }
 
@@ -64,6 +75,7 @@ public final class NetworkCapabilityResolver {
         if (cachedDevice != null) return cachedDevice;
 
         boolean supports5g = false;
+        boolean canCache = true;
 
         // Stage 1: Android Version Check (Android 11 / API 30+)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -71,23 +83,31 @@ public final class NetworkCapabilityResolver {
             if (executor != null) {
                 // Stage 2: Hardware Ceiling Check
                 CommandResult result = executor.execute("getprop ro.telephony.default_network");
-                if (result.isSuccess() && !result.getStdout().trim().isEmpty()) {
-                    String[] values = result.getStdout().trim().split(",");
-                    
-                    // Check if ANY value globally supports 5G (>= 23)
-                    for (String val : values) {
-                        Integer parsed = ShellValueParser.extractFirstInt(val);
-                        if (parsed != null && parsed >= 23) {
-                            supports5g = true;
-                            break;
+                if (result.isSuccess()) {
+                    if (!result.getStdout().trim().isEmpty()) {
+                        String[] values = result.getStdout().trim().split(",");
+                        
+                        // Check if ANY value globally supports 5G (>= 23)
+                        for (String val : values) {
+                            Integer parsed = ShellValueParser.extractFirstInt(val);
+                            if (parsed != null && parsed >= 23) {
+                                supports5g = true;
+                                break;
+                            }
                         }
                     }
+                } else {
+                    canCache = false;
                 }
+            } else {
+                canCache = false;
             }
         }
 
         NetworkCapabilities deviceCaps = new NetworkCapabilities(true, true, true, supports5g);
-        appPreferences.saveDeviceCapabilities(deviceCaps);
+        if (canCache) {
+            appPreferences.saveDeviceCapabilities(deviceCaps);
+        }
         return deviceCaps;
     }
 

--- a/app/src/main/java/com/dhangofa/networktoggle/telephony/NetworkModeReader.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/telephony/NetworkModeReader.java
@@ -7,15 +7,20 @@ import com.dhangofa.networktoggle.model.CommandResult;
 import com.dhangofa.networktoggle.model.ExecutionMode;
 import com.dhangofa.networktoggle.model.NetworkMode;
 import com.dhangofa.networktoggle.model.TargetSim;
+import android.content.Context;
+import android.provider.Settings;
 
 public final class NetworkModeReader {
+    private final Context context;
     private final AppPreferences appPreferences;
     private final SimResolver simResolver;
 
     public NetworkModeReader(
+            Context context,
             AppPreferences appPreferences,
             SimResolver simResolver
     ) {
+        this.context = context;
         this.appPreferences = appPreferences;
         this.simResolver = simResolver;
     }
@@ -29,6 +34,24 @@ public final class NetworkModeReader {
         TargetSim targetSim = appPreferences.getTargetSim();
         int targetSubId = simResolver.resolveTargetSubId(executionMode);
 
+        // NATIVE API FAST-PATH:
+        // Try reading natively without spawning shell if we have a valid SubId
+        if (simResolver.isValidSubId(targetSubId)) {
+            try {
+                String nativeValue = Settings.Global.getString(
+                        context.getContentResolver(),
+                        "preferred_network_mode" + targetSubId
+                );
+                
+                if (nativeValue != null && !nativeValue.trim().isEmpty() && !nativeValue.equalsIgnoreCase("null")) {
+                    return NetworkMode.fromLegacyMode(ShellValueParser.extractFirstInt(nativeValue));
+                }
+            } catch (Exception ignored) {
+                // Ignore SecurityExceptions or null pointers, proceed to shell fallback
+            }
+        }
+
+        // SHELL FALLBACK:
         String command;
         if (simResolver.isValidSubId(targetSubId)) {
             command = "value=$(settings get global preferred_network_mode"
@@ -37,6 +60,7 @@ public final class NetworkModeReader {
                     + "&& [ \"$value\" != \"null\" ]; then "
                     + "echo \"$value\"; else exit 1; fi";
         } else if (targetSim == TargetSim.AUTO) {
+            // Very slow nested shell fallback if native SubId resolution entirely failed
             command = "data_sim=$(settings get global multi_sim_data_call); "
                     + "[ \"$data_sim\" -gt 0 ] 2>/dev/null || exit 1; "
                     + "settings get global preferred_network_mode${data_sim}";

--- a/app/src/main/java/com/dhangofa/networktoggle/telephony/ShellValueParser.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/telephony/ShellValueParser.java
@@ -3,13 +3,14 @@ package com.dhangofa.networktoggle.telephony;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-final class ShellValueParser {
-    private static final Pattern NUMBER_PATTERN = Pattern.compile("\\d+");
+public final class ShellValueParser {
+    // Updated regex to support negative numbers (e.g., -1 for invalid slot)
+    private static final Pattern NUMBER_PATTERN = Pattern.compile("-?\\d+");
 
     private ShellValueParser() {
     }
 
-    static Integer extractFirstInt(String text) {
+    public static Integer extractFirstInt(String text) {
         try {
             if (text == null
                     || text.trim().isEmpty()
@@ -22,5 +23,36 @@ final class ShellValueParser {
         } catch (Exception ignored) {
             return null;
         }
+    }
+
+    /**
+     * Finds a specific key (e.g., "simSlotIndex=") and extracts the integer immediately after it.
+     */
+    public static Integer extractIntByKey(String text, String key) {
+        if (text == null || key == null) return null;
+        int index = text.indexOf(key);
+        if (index == -1) return null;
+
+        // Pass only the remainder of the string to find the first int
+        String remainder = text.substring(index + key.length());
+        return extractFirstInt(remainder);
+    }
+
+    /**
+     * Extracts a string value located between a starting key and an ending delimiter.
+     */
+    public static String extractStringByKey(String text, String key, String endDelimiter) {
+        if (text == null || key == null) return "";
+        int start = text.indexOf(key);
+        if (start == -1) return "";
+        start += key.length();
+
+        int end = text.indexOf(endDelimiter, start);
+        if (end == -1) {
+            end = text.indexOf(" ", start); // fallback to next space
+            if (end == -1) end = text.length();
+        }
+
+        return text.substring(start, end).trim();
     }
 }

--- a/app/src/main/java/com/dhangofa/networktoggle/telephony/SimResolver.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/telephony/SimResolver.java
@@ -1,6 +1,10 @@
 package com.dhangofa.networktoggle.telephony;
 
+import android.Manifest;
+import android.content.Context;
+import android.content.pm.PackageManager;
 import android.os.Build;
+import android.telephony.SubscriptionInfo;
 import android.telephony.SubscriptionManager;
 
 import com.dhangofa.networktoggle.command.CommandExecutor;
@@ -14,35 +18,126 @@ public final class SimResolver {
     public static final int INVALID_SLOT_INDEX = -1;
     public static final int INVALID_SUB_ID = -1;
 
+    private final Context context;
     private final AppPreferences appPreferences;
 
-    public SimResolver(AppPreferences appPreferences) {
+    // Data class to hold all extracted variables in one place
+    public static class SimInfo {
+        public final int subId;
+        public final int slotIndex;
+        public final String carrierName;
+
+        public SimInfo(int subId, int slotIndex, String carrierName) {
+            this.subId = subId;
+            this.slotIndex = slotIndex;
+            this.carrierName = carrierName;
+        }
+    }
+
+    public SimResolver(Context context, AppPreferences appPreferences) {
+        this.context = context.getApplicationContext();
         this.appPreferences = appPreferences;
     }
 
-    public int resolveTargetSlotIndex(ExecutionMode executionMode) {
+    /**
+     * Resolves IDs using Native APIs first.
+     * Silently falls back to Shell commands if permission is denied or device is too old.
+     */
+    public SimInfo resolveTargetSimInfo(ExecutionMode executionMode) {
         TargetSim targetSim = appPreferences.getTargetSim();
+        
+        int targetSubId = INVALID_SUB_ID;
+        int targetSlotIndex = INVALID_SLOT_INDEX;
+        String carrierName = "";
 
-        if (!targetSim.isAuto()) {
-            appPreferences.setAutoSimError(false);
-            return targetSim.getManualSlotIndex();
+        // 1. Safe Native APIs (No permission required)
+        if (targetSim.isAuto()) {
+            targetSubId = SubscriptionManager.getDefaultDataSubscriptionId();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                try {
+                    int nativeSlot = SubscriptionManager.getSlotIndex(targetSubId);
+                    if (isValidSlotIndex(nativeSlot)) targetSlotIndex = nativeSlot;
+                } catch (Exception ignored) {}
+            }
+        } else {
+            targetSlotIndex = targetSim.getManualSlotIndex();
         }
 
-        return resolveAutoSlotIndex(executionMode);
+        // 2. Protected Native APIs (Requires READ_PHONE_STATE)
+        boolean hasPermission = context.checkSelfPermission(Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED;
+        
+        if (hasPermission) {
+            SubscriptionManager sm = context.getSystemService(SubscriptionManager.class);
+            if (sm != null) {
+                try {
+                    if (isValidSubId(targetSubId)) {
+                        SubscriptionInfo info = sm.getActiveSubscriptionInfo(targetSubId);
+                        if (info != null) {
+                            if (info.getCarrierName() != null) carrierName = info.getCarrierName().toString();
+                            if (!isValidSlotIndex(targetSlotIndex)) targetSlotIndex = info.getSimSlotIndex();
+                        }
+                    } else if (isValidSlotIndex(targetSlotIndex)) {
+                        for (SubscriptionInfo info : sm.getActiveSubscriptionInfoList()) {
+                            if (info.getSimSlotIndex() == targetSlotIndex) {
+                                targetSubId = info.getSubscriptionId();
+                                if (info.getCarrierName() != null) carrierName = info.getCarrierName().toString();
+                                break;
+                            }
+                        }
+                    }
+                } catch (Exception ignored) {}
+            }
+        }
+
+        // 3. Shell Fallback (If missing permission, or older Android OS failed to map)
+        if (!isValidSubId(targetSubId) || !isValidSlotIndex(targetSlotIndex) || carrierName.isEmpty()) {
+            String command = "dumpsys isub | grep -E \"\\{id=[0-9]+ .*simSlotIndex=\"";
+            CommandExecutor executor = CommandExecutorFactory.forMode(executionMode);
+            
+            if (executor != null) {
+                CommandResult result = executor.execute(command);
+                if (result.isSuccess() && !result.getStdout().trim().isEmpty()) {
+                    String[] lines = result.getStdout().split("\\n");
+                    for (String line : lines) {
+                        Integer dumpSubId = ShellValueParser.extractIntByKey(line, "id=");
+                        Integer dumpSlotIndex = ShellValueParser.extractIntByKey(line, "simSlotIndex=");
+                        String dumpCarrier = ShellValueParser.extractStringByKey(line, "carrierName=", " nameSource=");
+
+                        if (dumpSubId != null && dumpSlotIndex != null) {
+                            if (targetSim.isAuto() && dumpSubId == targetSubId) {
+                                if (!isValidSlotIndex(targetSlotIndex)) targetSlotIndex = dumpSlotIndex;
+                                if (carrierName.isEmpty()) carrierName = dumpCarrier;
+                                break;
+                            } else if (!targetSim.isAuto() && dumpSlotIndex == targetSlotIndex) {
+                                if (!isValidSubId(targetSubId)) targetSubId = dumpSubId;
+                                if (carrierName.isEmpty()) carrierName = dumpCarrier;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // 4. Final Validation
+        if (isValidSubId(targetSubId) && isValidSlotIndex(targetSlotIndex)) {
+            if (targetSim.isAuto()) appPreferences.setAutoSimError(false);
+            return new SimInfo(targetSubId, targetSlotIndex, carrierName);
+        }
+
+        if (targetSim.isAuto()) appPreferences.setAutoSimError(true);
+        return null;
+    }
+
+    // Keeping backwards compatibility for existing app logic
+    public int resolveTargetSlotIndex(ExecutionMode executionMode) {
+        SimInfo info = resolveTargetSimInfo(executionMode);
+        return info != null ? info.slotIndex : INVALID_SLOT_INDEX;
     }
 
     public int resolveTargetSubId(ExecutionMode executionMode) {
-        TargetSim targetSim = appPreferences.getTargetSim();
-
-        if (targetSim == TargetSim.AUTO) {
-            int subId = SubscriptionManager.getDefaultDataSubscriptionId();
-            return isValidSubId(subId) ? subId : INVALID_SUB_ID;
-        }
-
-        return resolveSubIdFromDumpsys(
-                executionMode,
-                targetSim.getManualSlotIndex()
-        );
+        SimInfo info = resolveTargetSimInfo(executionMode);
+        return info != null ? info.subId : INVALID_SUB_ID;
     }
 
     public boolean isValidSlotIndex(int slotIndex) {
@@ -50,85 +145,6 @@ public final class SimResolver {
     }
 
     public boolean isValidSubId(int subId) {
-        return subId != SubscriptionManager.INVALID_SUBSCRIPTION_ID
-                && subId != INVALID_SUB_ID;
-    }
-
-    private int resolveAutoSlotIndex(ExecutionMode executionMode) {
-        int dataSubId = SubscriptionManager.getDefaultDataSubscriptionId();
-
-        if (!isValidSubId(dataSubId)) {
-            appPreferences.setAutoSimError(true);
-            return INVALID_SLOT_INDEX;
-        }
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            try {
-                int slotIndex = SubscriptionManager.getSlotIndex(dataSubId);
-                if (isValidSlotIndex(slotIndex)) {
-                    appPreferences.setAutoSimError(false);
-                    return slotIndex;
-                }
-            } catch (Exception ignored) {
-            }
-        }
-
-        int slotIndex = resolveSlotIndexFromDumpsys(executionMode, dataSubId);
-        if (isValidSlotIndex(slotIndex)) {
-            appPreferences.setAutoSimError(false);
-            return slotIndex;
-        }
-
-        appPreferences.setAutoSimError(true);
-        return INVALID_SLOT_INDEX;
-    }
-
-    private int resolveSlotIndexFromDumpsys(
-            ExecutionMode executionMode,
-            int dataSubId
-    ) {
-        String command = "dumpsys isub | grep -E \"\\{id=" + dataSubId
-                + "([^0-9]| )\" | head -n 1 "
-                + "| grep -o -E \"simSlotIndex=[0-9]+\" "
-                + "| cut -d '=' -f 2";
-
-        CommandResult result = execute(executionMode, command);
-        Integer slotIndex = result.isSuccess()
-                ? ShellValueParser.extractFirstInt(result.getStdout())
-                : null;
-
-        return slotIndex != null && isValidSlotIndex(slotIndex)
-                ? slotIndex
-                : INVALID_SLOT_INDEX;
-    }
-
-    private int resolveSubIdFromDumpsys(
-            ExecutionMode executionMode,
-            int slotIndex
-    ) {
-        String command = "dumpsys isub | grep -E \"simSlotIndex=" + slotIndex
-                + "([^0-9]| )\" | head -n 1 "
-                + "| grep -o -E \"\\{id=[0-9]+\" "
-                + "| cut -d '=' -f 2";
-
-        CommandResult result = execute(executionMode, command);
-        Integer subId = result.isSuccess()
-                ? ShellValueParser.extractFirstInt(result.getStdout())
-                : null;
-
-        return subId != null && subId > 0
-                ? subId
-                : INVALID_SUB_ID;
-    }
-
-    private CommandResult execute(
-            ExecutionMode executionMode,
-            String command
-    ) {
-        CommandExecutor executor = CommandExecutorFactory.forMode(executionMode);
-        if (executor == null) {
-            return CommandResult.failed(command, "No execution mode selected.");
-        }
-        return executor.execute(command);
+        return subId != SubscriptionManager.INVALID_SUBSCRIPTION_ID && subId != INVALID_SUB_ID;
     }
 }

--- a/app/src/main/java/com/dhangofa/networktoggle/ui/TileCycleUiController.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/ui/TileCycleUiController.java
@@ -7,6 +7,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.dhangofa.networktoggle.R;
+import com.dhangofa.networktoggle.config.AppPreferences;
 import com.dhangofa.networktoggle.cycle.TileCycleManager;
 import com.dhangofa.networktoggle.model.NetworkMode;
 
@@ -32,6 +33,14 @@ public final class TileCycleUiController {
     private final TextView cycleOrder;
     private boolean updatingUi;
 
+    private AppPreferences.NetworkCapabilities currentCaps;
+    private OnCycleChangedListener cycleChangedListener;
+    private boolean isAuthorized = true;
+
+    public interface OnCycleChangedListener {
+        void onCycleChanged(List<NetworkMode> newCycle);
+    }
+
     public TileCycleUiController(Activity activity, TileCycleManager cycleManager) {
         this.activity = activity;
         this.cycleManager = cycleManager;
@@ -52,8 +61,27 @@ public final class TileCycleUiController {
         cycleOrder = activity.findViewById(R.id.cycleOrderText);
     }
 
+    public void setOnCycleChangedListener(OnCycleChangedListener listener) {
+        this.cycleChangedListener = listener;
+    }
+
     public void initialize() {
         refresh();
+        
+        android.view.View.OnTouchListener lockTouch = (v, event) -> {
+            if (!isAuthorized && event.getAction() == android.view.MotionEvent.ACTION_DOWN) {
+                showToast("Please authorize Root or Shizuku to configure toggles.");
+                return true; // Consume event to prevent visual change
+            }
+            return false;
+        };
+        modePref5g.setOnTouchListener(lockTouch);
+        modePref4g.setOnTouchListener(lockTouch);
+        modePref3g.setOnTouchListener(lockTouch);
+        mode5gOnly.setOnTouchListener(lockTouch);
+        mode4gOnly.setOnTouchListener(lockTouch);
+        mode2gOnly.setOnTouchListener(lockTouch);
+
         modePref5g.setOnCheckedChangeListener((button, selected) ->
                 handleSelection(NetworkMode.PREFERRED_5G, selected));
         modePref4g.setOnCheckedChangeListener((button, selected) ->
@@ -68,11 +96,74 @@ public final class TileCycleUiController {
                 handleSelection(NetworkMode.TWO_G_ONLY, selected));
     }
 
+    public void setAuthorized(boolean authorized) {
+        if (this.isAuthorized == authorized) return;
+        this.isAuthorized = authorized;
+        float alpha = authorized ? 1.0f : 0.4f;
+        
+        View card = activity.findViewById(R.id.cardTileCycle);
+        if (card != null) {
+            card.setAlpha(alpha);
+        }
+    }
+
+    public void applyCapabilities(AppPreferences.NetworkCapabilities caps) {
+        if (caps == null) return;
+        this.currentCaps = caps;
+        
+        modePref5g.setAlpha(caps.supports5g ? 1.0f : 0.4f);
+        mode5gOnly.setAlpha(caps.supports5g ? 1.0f : 0.4f);
+        
+        modePref3g.setAlpha(caps.supports3g ? 1.0f : 0.4f);
+        
+        mode2gOnly.setAlpha(caps.supports2g ? 1.0f : 0.4f);
+        
+        if (cycleManager.forceRemoveUnsupportedAndAutoFill(caps)) {
+            showToast("Cycle auto-adjusted for current SIM capabilities");
+            if (cycleChangedListener != null) {
+                cycleChangedListener.onCycleChanged(cycleManager.getCycle());
+            }
+        }
+
+        refresh();
+    }
+
     private void handleSelection(NetworkMode mode, boolean selected) {
         if (updatingUi) return;
 
+        if (!isAuthorized) {
+            showToast("Please authorize Root or Shizuku to configure toggles.");
+            refresh(); // Revert checkbox visual change
+            return;
+        }
+
+        if (selected && currentCaps != null) {
+            boolean supported = true;
+            String reason = "";
+            if ((mode == NetworkMode.PREFERRED_5G || mode == NetworkMode.FIVE_G_ONLY) && !currentCaps.supports5g) {
+                supported = false;
+                reason = "5G is not supported by your device or current carrier.";
+            } else if (mode == NetworkMode.PREFERRED_3G && !currentCaps.supports3g) {
+                supported = false;
+                reason = "3G is disabled or not supported by your current carrier.";
+            } else if (mode == NetworkMode.TWO_G_ONLY && !currentCaps.supports2g) {
+                supported = false;
+                reason = "2G is disabled or not supported by your current carrier.";
+            }
+            
+            if (!supported) {
+                showToast(reason);
+                refresh(); // Revert UI to match the actual saved cycle
+                return;
+            }
+        }
+
         TileCycleManager.ChangeResult result = cycleManager.setSelected(mode, selected);
-        if (result == TileCycleManager.ChangeResult.MINIMUM_REACHED) {
+        if (result == TileCycleManager.ChangeResult.CHANGED) {
+            if (cycleChangedListener != null) {
+                cycleChangedListener.onCycleChanged(cycleManager.getCycle());
+            }
+        } else if (result == TileCycleManager.ChangeResult.MINIMUM_REACHED) {
             showToast("Select at least 2 tile modes.");
         } else if (result == TileCycleManager.ChangeResult.MAXIMUM_REACHED) {
             showToast("You can select up to 3 tile modes.");

--- a/app/src/main/java/com/dhangofa/networktoggle/ui/TileCycleUiController.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/ui/TileCycleUiController.java
@@ -1,6 +1,7 @@
 package com.dhangofa.networktoggle.ui;
 
 import android.app.Activity;
+import android.view.View;
 import android.widget.CheckBox;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -14,10 +15,19 @@ import java.util.List;
 public final class TileCycleUiController {
     private final Activity activity;
     private final TileCycleManager cycleManager;
-    private final CheckBox mode5gOnly;
-    private final CheckBox mode4gOnly;
+    
     private final CheckBox modePref5g;
     private final CheckBox modePref4g;
+    private final CheckBox modePref3g;
+    private final CheckBox mode5gOnly;
+    private final CheckBox mode4gOnly;
+    private final CheckBox mode2gOnly;
+    
+    private final View separatorCyclePref1;
+    private final View separatorCyclePref2;
+    private final View separatorCycleOnly1;
+    private final View separatorCycleOnly2;
+    
     private final TextView selectedCount;
     private final TextView cycleOrder;
     private boolean updatingUi;
@@ -25,24 +35,37 @@ public final class TileCycleUiController {
     public TileCycleUiController(Activity activity, TileCycleManager cycleManager) {
         this.activity = activity;
         this.cycleManager = cycleManager;
-        mode5gOnly = activity.findViewById(R.id.cycle5gOnly);
-        mode4gOnly = activity.findViewById(R.id.cycle4gOnly);
+        
         modePref5g = activity.findViewById(R.id.cyclePreferred5g);
         modePref4g = activity.findViewById(R.id.cyclePreferred4g);
+        modePref3g = activity.findViewById(R.id.cyclePreferred3g);
+        mode5gOnly = activity.findViewById(R.id.cycle5gOnly);
+        mode4gOnly = activity.findViewById(R.id.cycle4gOnly);
+        mode2gOnly = activity.findViewById(R.id.cycle2gOnly);
+        
+        separatorCyclePref1 = activity.findViewById(R.id.separatorCyclePref1);
+        separatorCyclePref2 = activity.findViewById(R.id.separatorCyclePref2);
+        separatorCycleOnly1 = activity.findViewById(R.id.separatorCycleOnly1);
+        separatorCycleOnly2 = activity.findViewById(R.id.separatorCycleOnly2);
+        
         selectedCount = activity.findViewById(R.id.cycleSelectedCount);
         cycleOrder = activity.findViewById(R.id.cycleOrderText);
     }
 
     public void initialize() {
         refresh();
-        mode5gOnly.setOnCheckedChangeListener((button, selected) ->
-                handleSelection(NetworkMode.FIVE_G_ONLY, selected));
-        mode4gOnly.setOnCheckedChangeListener((button, selected) ->
-                handleSelection(NetworkMode.FOUR_G_ONLY, selected));
         modePref5g.setOnCheckedChangeListener((button, selected) ->
                 handleSelection(NetworkMode.PREFERRED_5G, selected));
         modePref4g.setOnCheckedChangeListener((button, selected) ->
                 handleSelection(NetworkMode.PREFERRED_4G, selected));
+        modePref3g.setOnCheckedChangeListener((button, selected) ->
+                handleSelection(NetworkMode.PREFERRED_3G, selected));
+        mode5gOnly.setOnCheckedChangeListener((button, selected) ->
+                handleSelection(NetworkMode.FIVE_G_ONLY, selected));
+        mode4gOnly.setOnCheckedChangeListener((button, selected) ->
+                handleSelection(NetworkMode.FOUR_G_ONLY, selected));
+        mode2gOnly.setOnCheckedChangeListener((button, selected) ->
+                handleSelection(NetworkMode.TWO_G_ONLY, selected));
     }
 
     private void handleSelection(NetworkMode mode, boolean selected) {
@@ -60,10 +83,20 @@ public final class TileCycleUiController {
     private void refresh() {
         updatingUi = true;
         List<NetworkMode> cycle = cycleManager.getCycle();
-        mode5gOnly.setChecked(cycle.contains(NetworkMode.FIVE_G_ONLY));
-        mode4gOnly.setChecked(cycle.contains(NetworkMode.FOUR_G_ONLY));
+        
         modePref5g.setChecked(cycle.contains(NetworkMode.PREFERRED_5G));
         modePref4g.setChecked(cycle.contains(NetworkMode.PREFERRED_4G));
+        modePref3g.setChecked(cycle.contains(NetworkMode.PREFERRED_3G));
+        mode5gOnly.setChecked(cycle.contains(NetworkMode.FIVE_G_ONLY));
+        mode4gOnly.setChecked(cycle.contains(NetworkMode.FOUR_G_ONLY));
+        mode2gOnly.setChecked(cycle.contains(NetworkMode.TWO_G_ONLY));
+        
+        // Hide separators if either adjacent button is checked to create a seamless pill background
+        separatorCyclePref1.setVisibility(modePref5g.isChecked() || modePref4g.isChecked() ? View.INVISIBLE : View.VISIBLE);
+        separatorCyclePref2.setVisibility(modePref4g.isChecked() || modePref3g.isChecked() ? View.INVISIBLE : View.VISIBLE);
+        separatorCycleOnly1.setVisibility(mode5gOnly.isChecked() || mode4gOnly.isChecked() ? View.INVISIBLE : View.VISIBLE);
+        separatorCycleOnly2.setVisibility(mode4gOnly.isChecked() || mode2gOnly.isChecked() ? View.INVISIBLE : View.VISIBLE);
+        
         selectedCount.setText("Selected: " + cycle.size() + "/3");
         cycleOrder.setText(buildOrderText(cycle));
         updatingUi = false;
@@ -82,4 +115,3 @@ public final class TileCycleUiController {
         Toast.makeText(activity, message, Toast.LENGTH_SHORT).show();
     }
 }
-

--- a/app/src/main/java/com/dhangofa/networktoggle/util/DiagnosticReporter.java
+++ b/app/src/main/java/com/dhangofa/networktoggle/util/DiagnosticReporter.java
@@ -1,0 +1,48 @@
+package com.dhangofa.networktoggle.util;
+
+import android.os.Build;
+import com.dhangofa.networktoggle.config.AppPreferences;
+import com.dhangofa.networktoggle.model.DiagnosticError;
+import com.dhangofa.networktoggle.telephony.SimResolver;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+public class DiagnosticReporter {
+
+    public static String generateReport(AppPreferences prefs, SimResolver simResolver) {
+        DiagnosticError error = prefs.getLastError();
+        if (error == null) {
+            return "No recent errors recorded.";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US);
+
+        sb.append("--- NETWORK TOGGLE DIAGNOSTIC REPORT ---\n");
+        sb.append("Time: ").append(sdf.format(new Date(error.timestamp))).append("\n\n");
+
+        sb.append("[DEVICE INFO]\n");
+        sb.append("Manufacturer: ").append(Build.MANUFACTURER).append("\n");
+        sb.append("Brand: ").append(Build.BRAND).append("\n");
+        sb.append("Device: ").append(Build.DEVICE).append("\n");
+        sb.append("Model: ").append(Build.MODEL).append("\n");
+        sb.append("Android Version: ").append(Build.VERSION.RELEASE).append("\n");
+        sb.append("SDK Level: ").append(Build.VERSION.SDK_INT).append("\n\n");
+
+        sb.append("[APP STATE]\n");
+        sb.append("Execution Mode: ").append(prefs.getExecutionMode().name()).append("\n");
+        sb.append("Target SIM Setting: ").append(prefs.getTargetSim().name()).append("\n");
+        
+        int slotIndex = simResolver.resolveTargetSlotIndex(prefs.getExecutionMode());
+        sb.append("Resolved Slot Index: ").append(slotIndex).append("\n\n");
+
+        sb.append("[ERROR DETAILS]\n");
+        sb.append("Command Attempted:\n").append(error.command).append("\n\n");
+        sb.append("Standard Error (stderr):\n").append(error.stderr).append("\n\n");
+        
+        sb.append("--- END OF REPORT ---");
+
+        return sb.toString();
+    }
+}

--- a/app/src/main/res/color/color_segmented_text_cycle.xml
+++ b/app/src/main/res/color/color_segmented_text_cycle.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true" android:color="@color/cycle_segmented_text_selected" />
+    <item android:color="@color/segmented_text_unselected" />
+</selector>

--- a/app/src/main/res/color/color_segmented_text_exec.xml
+++ b/app/src/main/res/color/color_segmented_text_exec.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true" android:color="@color/exec_segmented_text_selected" />
+    <item android:color="@color/segmented_text_unselected" />
+</selector>

--- a/app/src/main/res/drawable/ic_arrow_right.xml
+++ b/app/src/main/res/drawable/ic_arrow_right.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M10,17L15,12L10,7V17Z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#FFFFFF"
+        android:fillType="nonZero"
+        android:pathData="M54,28 A2,2 0 0,0 52,30 L52,42 L42,42 A2,2 0 0,0 40,44 L40,78 A2,2 0 0,0 42,80 L66,80 A2,2 0 0,0 68,78 L68,44 A2,2 0 0,0 66,42 L56,42 L56,30 A2,2 0 0,0 54,28 Z M45,47 L63,47 L63,75 L45,75 Z M32,46 A2,2 0 0,0 30,48 C30,58 34,68 40,75 A2,2 0 0,0 43,72 C37,66 34,58 34,48 A2,2 0 0,0 32,46 Z M76,46 A2,2 0 0,0 74,48 C74,58 71,66 65,72 A2,2 0 0,0 68,75 C74,68 78,58 78,48 A2,2 0 0,0 76,46 Z M23,36 A2,2 0 0,0 21,38 C21,52 26,65 35,76 A2,2 0 0,0 38,73 C29,63 25,51 25,38 A2,2 0 0,0 23,36 Z M85,36 A2,2 0 0,0 83,38 C83,51 79,63 70,73 A2,2 0 0,0 73,76 C82,65 87,52 87,38 A2,2 0 0,0 85,36 Z"
+        android:strokeWidth="1"
+        android:strokeColor="#00000000" />
+</vector>

--- a/app/src/main/res/drawable/ic_speed.xml
+++ b/app/src/main/res/drawable/ic_speed.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/brand_primary">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M2,12c0,-5.5 4.5,-10 10,-10s10,4.5 10,10c0,2.8 -1.1,5.3 -2.9,7.1l-1.4,-1.4C19.1,16.2 20,14.2 20,12c0,-4.4 -3.6,-8 -8,-8S4,7.6 4,12c0,2.2 0.9,4.2 2.3,5.7l-1.4,1.4C3.1,17.3 2,14.8 2,12zM10.8,11L8,13.8l1.4,1.4l2.6,-2.6l4.6,4.6l1.4,-1.4L10.8,11z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_warning.xml
+++ b/app/src/main/res/drawable/ic_warning.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M1,21H23L12,2ZM13,18H11V16H13ZM13,14H11V10H13Z"/>
+</vector>

--- a/app/src/main/res/drawable/section_outline_bg.xml
+++ b/app/src/main/res/drawable/section_outline_bg.xml
@@ -2,13 +2,10 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="@color/card_surface" />
-    <corners android:radius="16dp" />
-    <stroke
-        android:width="1dp"
-        android:color="@color/card_border" />
+    <corners android:radius="24dp" />
     <padding
-        android:left="14dp"
-        android:top="14dp"
-        android:right="14dp"
-        android:bottom="14dp" />
+        android:left="16dp"
+        android:top="16dp"
+        android:right="16dp"
+        android:bottom="16dp" />
 </shape>

--- a/app/src/main/res/drawable/selector_segmented_tab.xml
+++ b/app/src/main/res/drawable/selector_segmented_tab.xml
@@ -3,14 +3,14 @@
     <item android:state_checked="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/segmented_selected" />
-            <corners android:radius="8dp" />
+            <corners android:radius="50dp" />
         </shape>
     </item>
 
     <item>
         <shape android:shape="rectangle">
             <solid android:color="@android:color/transparent" />
-            <corners android:radius="8dp" />
+            <corners android:radius="50dp" />
         </shape>
     </item>
 

--- a/app/src/main/res/drawable/selector_segmented_tab_cycle.xml
+++ b/app/src/main/res/drawable/selector_segmented_tab_cycle.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/cycle_segmented_selected" />
+            <corners android:radius="10dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/transparent" />
+            <corners android:radius="10dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/selector_segmented_tab_exec.xml
+++ b/app/src/main/res/drawable/selector_segmented_tab_exec.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/exec_segmented_selected" />
+            <corners android:radius="50dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/transparent" />
+            <corners android:radius="50dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/selector_segmented_tab_rect.xml
+++ b/app/src/main/res/drawable/selector_segmented_tab_rect.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/segmented_selected" />
+            <corners android:radius="10dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/transparent" />
+            <corners android:radius="10dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/shape_app_icon_bg.xml
+++ b/app/src/main/res/drawable/shape_app_icon_bg.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/brand_primary_container" />
+    <corners android:radius="12dp" />
+</shape>

--- a/app/src/main/res/drawable/shape_button_primary.xml
+++ b/app/src/main/res/drawable/shape_button_primary.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/brand_primary" />
+    <corners android:radius="24dp" />
+</shape>

--- a/app/src/main/res/drawable/shape_cycle_card_bg.xml
+++ b/app/src/main/res/drawable/shape_cycle_card_bg.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/cycle_card_surface" />
+    <corners android:radius="24dp" />
+    <padding
+        android:left="16dp"
+        android:top="16dp"
+        android:right="16dp"
+        android:bottom="16dp" />
+</shape>

--- a/app/src/main/res/drawable/shape_cycle_order_badge.xml
+++ b/app/src/main/res/drawable/shape_cycle_order_badge.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/segmented_container" />
+    <corners android:radius="20dp" />
+</shape>

--- a/app/src/main/res/drawable/shape_dialog_bg.xml
+++ b/app/src/main/res/drawable/shape_dialog_bg.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/card_surface" />
+    <corners
+        android:topLeftRadius="24dp"
+        android:topRightRadius="24dp" />
+</shape>

--- a/app/src/main/res/drawable/shape_exec_card_bg.xml
+++ b/app/src/main/res/drawable/shape_exec_card_bg.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/exec_card_surface" />
+    <corners android:radius="24dp" />
+    <padding
+        android:left="16dp"
+        android:top="16dp"
+        android:right="16dp"
+        android:bottom="16dp" />
+</shape>

--- a/app/src/main/res/drawable/shape_floating_footer.xml
+++ b/app/src/main/res/drawable/shape_floating_footer.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/card_surface" />
+    <corners android:radius="32dp" />
+</shape>

--- a/app/src/main/res/drawable/shape_qs_hint_bg.xml
+++ b/app/src/main/res/drawable/shape_qs_hint_bg.xml
@@ -2,8 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="@color/qs_hint_bg" />
-    <corners android:radius="16dp" />
-    <stroke
-        android:width="1dp"
-        android:color="@color/card_border" />
+    <corners android:radius="24dp" />
 </shape>

--- a/app/src/main/res/drawable/shape_radio_item_bg.xml
+++ b/app/src/main/res/drawable/shape_radio_item_bg.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <solid android:color="?android:attr/colorBackground" />
-    <corners android:radius="10dp" />
-</shape>

--- a/app/src/main/res/drawable/shape_segmented_container.xml
+++ b/app/src/main/res/drawable/shape_segmented_container.xml
@@ -2,6 +2,6 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="@color/segmented_container" />
-    <corners android:radius="12dp" />
+    <corners android:radius="50dp" />
 
 </shape>

--- a/app/src/main/res/drawable/shape_segmented_container_rect.xml
+++ b/app/src/main/res/drawable/shape_segmented_container_rect.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/segmented_container" />
+    <corners android:radius="12dp" />
+</shape>

--- a/app/src/main/res/drawable/shape_small_divider.xml
+++ b/app/src/main/res/drawable/shape_small_divider.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/card_border" />
+    <corners android:radius="2dp" />
+</shape>

--- a/app/src/main/res/drawable/social_icon_bg.xml
+++ b/app/src/main/res/drawable/social_icon_bg.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="oval">
+    android:shape="rectangle">
     <solid android:color="@color/social_button_bg" />
-    <stroke
-        android:width="1dp"
-        android:color="@color/card_border" />
+    <corners android:radius="12dp" />
 </shape>

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -208,6 +208,8 @@
                         android:textColor="@color/text_secondary" />
                 </LinearLayout>
             </LinearLayout>
+            
+            <include layout="@layout/view_error_banner" />
 
             <!-- Parallel 2-Column Cards Row in Landscape -->
             <LinearLayout

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -1,0 +1,241 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@color/surface_background">
+
+    <!-- Landscape Header: Top Action Bar Merged with Developer Section -->
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/card_surface"
+        android:paddingHorizontal="20dp"
+        android:paddingVertical="10dp"
+        android:elevation="6dp"
+        android:outlineProvider="bounds"
+        android:gravity="center_vertical">
+
+        <!-- App Brand Left Group -->
+        <LinearLayout
+            android:id="@+id/brandGroup"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <!-- App Icon -->
+            <FrameLayout
+                android:id="@+id/appIconFrame"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:layout_marginEnd="10dp"
+                android:background="@drawable/shape_app_icon_bg">
+                
+                <ImageView
+                    android:layout_width="38dp"
+                    android:layout_height="38dp"
+                    android:layout_gravity="center"
+                    android:src="@drawable/ic_launcher_foreground"
+                    android:tint="@color/brand_on_primary_container"
+                    android:contentDescription="NetToggle" />
+            </FrameLayout>
+
+            <!-- App Title -->
+            <TextView
+                android:id="@+id/appTitleText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="NetToggle"
+                android:textSize="22sp"
+                android:fontFamily="sans-serif-black"
+                android:textColor="@color/text_primary"
+                android:letterSpacing="-0.02" />
+
+            <!-- App Version Badge -->
+            <TextView
+                android:id="@+id/appVersionText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:background="@drawable/shape_pill_badge_bg"
+                android:fontFamily="sans-serif-medium"
+                android:gravity="center"
+                android:minHeight="22dp"
+                android:paddingHorizontal="8dp"
+                android:paddingVertical="2dp"
+                android:text="v0.0.0"
+                android:textColor="@color/brand_on_primary_container"
+                android:textSize="12sp"
+                android:textStyle="bold" />
+        </LinearLayout>
+
+        <!-- Developer Action Group on Right -->
+        <LinearLayout
+            android:id="@+id/developerTopGroup"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <ImageView
+                android:id="@+id/developerPersonIcon"
+                android:layout_width="34dp"
+                android:layout_height="34dp"
+                android:padding="7dp"
+                android:src="@drawable/ic_person"
+                android:tint="@color/accent_pink"
+                android:background="@drawable/social_icon_bg"
+                android:contentDescription="Developer"
+                android:layout_marginEnd="8dp" />
+
+            <TextView
+                android:id="@+id/developerNameText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Dhangofa"
+                android:textSize="13sp"
+                android:fontFamily="sans-serif-medium"
+                android:textStyle="bold"
+                android:textColor="@color/text_primary"
+                android:layout_marginEnd="12dp" />
+
+            <ImageView
+                android:id="@+id/githubLink"
+                android:layout_width="34dp"
+                android:layout_height="34dp"
+                android:padding="7dp"
+                android:src="@drawable/ic_github"
+                android:tint="@color/text_primary"
+                android:background="@drawable/social_icon_bg"
+                android:layout_marginEnd="8dp"
+                android:clickable="true"
+                android:focusable="true" />
+
+            <ImageView
+                android:id="@+id/telegramLink"
+                android:layout_width="34dp"
+                android:layout_height="34dp"
+                android:padding="7dp"
+                android:src="@drawable/ic_telegram"
+                android:tint="@color/text_primary"
+                android:background="@drawable/social_icon_bg"
+                android:clickable="true"
+                android:focusable="true" />
+        </LinearLayout>
+    </RelativeLayout>
+
+    <!-- Scrollable Content in Landscape -->
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:fillViewport="true"
+        android:clipToPadding="false"
+        android:clipChildren="false"
+        android:overScrollMode="never">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingHorizontal="20dp"
+            android:paddingTop="14dp"
+            android:paddingBottom="36dp"
+            android:clipChildren="false"
+            android:clipToPadding="false">
+
+            <!-- Description Text -->
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:fontFamily="sans-serif"
+                android:lineSpacingExtra="2dp"
+                android:layout_marginBottom="10dp"
+                android:text="Switch between 5G, 4G, 3G, 2G, and Preferred network modes directly from Quick Settings."
+                android:textColor="@color/text_secondary"
+                android:textSize="12sp" />
+
+            <!-- Integrated Quick Settings Ready Header Banner -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:background="@drawable/shape_qs_hint_bg"
+                android:padding="12dp"
+                android:gravity="center_vertical"
+                android:layout_marginBottom="12dp">
+
+                <FrameLayout
+                    android:layout_width="38dp"
+                    android:layout_height="38dp"
+                    android:background="@drawable/shape_pill_badge_bg"
+                    android:layout_marginEnd="12dp">
+
+                    <ImageView
+                        android:layout_width="20dp"
+                        android:layout_height="20dp"
+                        android:layout_gravity="center"
+                        android:src="@drawable/ic_network_bars"
+                        android:tint="@color/brand_primary"
+                        android:contentDescription="QS Tile" />
+                </FrameLayout>
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="Quick Settings Ready"
+                        android:textSize="13sp"
+                        android:fontFamily="sans-serif-medium"
+                        android:textStyle="bold"
+                        android:textColor="@color/text_primary" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="Add NetToggle tile to your Control Center or Quick Settings"
+                        android:textSize="11sp"
+                        android:textColor="@color/text_secondary" />
+                </LinearLayout>
+            </LinearLayout>
+
+            <!-- Parallel 2-Column Cards Row in Landscape -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:baselineAligned="false"
+                android:clipChildren="false"
+                android:clipToPadding="false"
+                android:paddingVertical="8dp">
+
+                <!-- Left Column: Execution Mode + Target SIM Card -->
+                <include 
+                    layout="@layout/view_execution_card"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:layout_marginEnd="8dp" />
+
+                <!-- Right Column: Quick Tile Cycle Card (Equal match_parent height) -->
+                <include 
+                    layout="@layout/view_tile_cycle_card"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:layout_marginStart="8dp" />
+            </LinearLayout>
+
+        </LinearLayout>
+    </ScrollView>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -149,8 +149,18 @@
 				</LinearLayout>
 			</LinearLayout>
 	
+            <!-- Error Banner Include -->
+            <include 
+				android:id="@+id/cardErrorBanner"
+				layout="@layout/view_error_banner"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:layout_marginBottom="12dp"
+				android:visibility="gone" />
+
             <!-- Execution Mode Card Include -->
             <include 
+                android:id="@+id/cardExecutionAndTarget"
                 layout="@layout/view_execution_card"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -158,6 +168,7 @@
 			
 			<!-- Tile Cycle Card Include -->
 			<include 
+			    android:id="@+id/cardTileCycle"
 				layout="@layout/view_tile_cycle_card"
 				android:layout_width="match_parent"
 				android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,405 +1,251 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/surface_background"
-    android:fillViewport="true"
-    android:overScrollMode="never">
+    android:orientation="vertical"
+    android:background="@color/surface_background">
 
-    <LinearLayout
+    <!-- Header Section: Custom Action Bar (Matches Status Bar Color) -->
+    <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
+        android:background="@color/card_surface"
         android:paddingHorizontal="16dp"
-		android:paddingTop="16dp"
-		android:paddingBottom="20dp"
-        android:gravity="center_horizontal">
+        android:paddingTop="12dp"
+        android:paddingBottom="12dp"
+        android:elevation="6dp"
+        android:outlineProvider="bounds"
+        android:gravity="center_vertical">
 
-        <!-- Header Section: Integrated Hero Branding -->
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-			android:gravity="center_horizontal"
-			android:paddingTop="4dp"
-			android:paddingBottom="12dp">
-
-            <FrameLayout
-				android:layout_width="56dp"
-				android:layout_height="56dp"
-				android:layout_marginBottom="10dp"
-				android:background="@drawable/shape_pill_badge_bg">
-
-                <ImageView
-                    android:layout_width="30dp"
-                    android:layout_height="30dp"
-                    android:layout_gravity="center"
-                    android:src="@drawable/ic_network_bars"
-                    android:tint="@color/brand_primary"
-                    android:contentDescription="NetToggle" />
-            </FrameLayout>
-
-            <TextView
-                android:id="@+id/appTitleText"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="NetToggle"
-                android:textSize="24sp"
-                android:fontFamily="sans-serif-medium"
-                android:textStyle="bold"
-                android:textColor="@color/text_primary"
-                android:letterSpacing="0.02"
-                android:layout_marginBottom="4dp" />
-			<TextView
-				android:id="@+id/appVersionText"
-				android:layout_width="wrap_content"
-				android:layout_height="wrap_content"
-				android:layout_marginBottom="8dp"
-				android:background="@drawable/shape_pill_badge_bg"
-				android:fontFamily="sans-serif-medium"
-				android:gravity="center"
-				android:minHeight="24dp"
-				android:paddingHorizontal="10dp"
-				android:paddingVertical="3dp"
-				android:text="v0.0.0"
-				android:textColor="@color/brand_on_primary_container"
-				android:textSize="11sp"
-				android:textStyle="bold" />
-            <TextView
-				android:layout_width="match_parent"
-				android:layout_height="wrap_content"
-				android:fontFamily="sans-serif"
-				android:gravity="center"
-				android:lineSpacingExtra="1dp"
-				android:paddingHorizontal="8dp"
-				android:text="Switch Network between 5G, 4G, Preferred 5G and Preferred 4G from Quick Settings."
-				android:textColor="@color/text_secondary"
-				android:textSize="12sp" />
-        </LinearLayout>
-
-        <!-- Quick Settings Tile Hint Card -->
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:background="@drawable/shape_qs_hint_bg"
-            android:padding="12dp"
-            android:gravity="center_vertical"
-            android:layout_marginTop="0dp"
-            android:layout_marginBottom="12dp">
-
-            <FrameLayout
-                android:layout_width="38dp"
-                android:layout_height="38dp"
-                android:background="@drawable/shape_pill_badge_bg"
-                android:layout_marginEnd="10dp">
-
-                <ImageView
-                    android:layout_width="20dp"
-                    android:layout_height="20dp"
-                    android:layout_gravity="center"
-                    android:src="@drawable/ic_network_bars"
-                    android:tint="@color/brand_primary"
-                    android:contentDescription="QS Tile" />
-            </FrameLayout>
-
-            <LinearLayout
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:orientation="vertical">
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="Quick Settings Ready"
-                    android:textSize="13sp"
-                    android:fontFamily="sans-serif-medium"
-                    android:textStyle="bold"
-                    android:textColor="@color/text_primary" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="Add NetToggle tile to your Control Center or Quick Settings"
-                    android:textSize="11sp"
-                    android:textColor="@color/text_secondary" />
-            </LinearLayout>
-        </LinearLayout>
-
-        <!-- Card 1: Execution Mode -->
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:background="@drawable/section_outline_bg"
-            android:padding="12dp"
-            android:layout_marginBottom="12dp">
-
-            <RelativeLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="10dp">
-                
-                <LinearLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:gravity="center_vertical">
-                    <ImageView
-                        android:layout_width="16dp"
-                        android:layout_height="16dp"
-                        android:src="@drawable/ic_shield"
-                        android:tint="@color/brand_primary"
-                        android:layout_marginEnd="6dp" />
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="Execution Mode"
-                        android:textSize="13sp"
-                        android:fontFamily="sans-serif-medium"
-                        android:textStyle="bold"
-                        android:textColor="@color/text_primary" />
-                </LinearLayout>
-
-                <TextView
-                    android:id="@+id/shizukuStatusText"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_alignParentEnd="true"
-                    android:text="Authorized"
-                    android:background="@drawable/shape_status_badge_success"
-                    android:textColor="#4ADE80"
-                    android:textSize="10sp"
-                    android:textStyle="bold"
-                    android:paddingHorizontal="8dp"
-                    android:paddingVertical="4dp" />
-            </RelativeLayout>
-
-            <!-- Segmented Control for Execution Mode -->
-            <RadioGroup
-                android:id="@+id/modeRadioGroup"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:background="@drawable/shape_segmented_container"
-                android:padding="4dp">
-                
-                <RadioButton
-                    android:id="@+id/radioRoot"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="Root"
-                    android:button="@null"
-                    android:gravity="center"
-					android:minHeight="40dp"
-                    android:paddingVertical="8dp"
-                    android:background="@drawable/selector_segmented_tab"
-                    android:textColor="@color/color_segmented_text"
-                    android:textSize="12sp"
-                    android:textStyle="bold" />
-
-                <RadioButton
-                    android:id="@+id/radioShizuku"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="Shizuku"
-                    android:button="@null"
-                    android:gravity="center"
-					android:minHeight="40dp"
-                    android:paddingVertical="8dp"
-                    android:background="@drawable/selector_segmented_tab"
-                    android:textColor="@color/color_segmented_text"
-                    android:textSize="12sp"
-                    android:textStyle="bold" />
-            </RadioGroup>
-        </LinearLayout>
-
-        <!-- Card 2: Target SIM -->
-        <LinearLayout
-            android:id="@+id/targetSimCard"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:background="@drawable/section_outline_bg"
-            android:padding="12dp"
-            android:layout_marginBottom="12dp">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:gravity="center_vertical"
-                android:layout_marginBottom="10dp">
-                <ImageView
-                    android:layout_width="16dp"
-                    android:layout_height="16dp"
-                    android:src="@drawable/ic_smartphone"
-                    android:tint="@color/brand_primary"
-                    android:layout_marginEnd="6dp" />
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="Target SIM"
-                    android:textSize="13sp"
-                    android:fontFamily="sans-serif-medium"
-                    android:textStyle="bold"
-                    android:textColor="@color/text_primary" />
-            </LinearLayout>
-
-            <!-- Segmented Control for Target SIM -->
-            <RadioGroup
-                android:id="@+id/targetSimRadioGroup"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:background="@drawable/shape_segmented_container"
-                android:padding="4dp">
-                
-                <RadioButton
-                    android:id="@+id/radioSimAuto"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="Auto"
-                    android:button="@null"
-                    android:gravity="center"
-					android:minHeight="40dp"
-                    android:paddingVertical="8dp"
-                    android:background="@drawable/selector_segmented_tab"
-                    android:textColor="@color/color_segmented_text"
-                    android:textSize="12sp"
-                    android:textStyle="bold" />
-
-                <RadioButton
-                    android:id="@+id/radioSim1"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="SIM 1"
-                    android:button="@null"
-                    android:gravity="center"
-					android:minHeight="40dp"
-                    android:paddingVertical="8dp"
-                    android:background="@drawable/selector_segmented_tab"
-                    android:textColor="@color/color_segmented_text"
-                    android:textSize="12sp"
-                    android:textStyle="bold" />
-
-                <RadioButton
-                    android:id="@+id/radioSim2"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="SIM 2"
-                    android:button="@null"
-                    android:gravity="center"
-					android:minHeight="40dp"
-                    android:paddingVertical="8dp"
-                    android:background="@drawable/selector_segmented_tab"
-                    android:textColor="@color/color_segmented_text"
-                    android:textSize="12sp"
-                    android:textStyle="bold" />
-            </RadioGroup>
-
-            <TextView
-                android:id="@+id/autoSimWarningText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="Auto failed"
-                android:textSize="11sp"
-                android:gravity="center"
-                android:textColor="@color/status_error_text"
-                android:background="@drawable/shape_status_badge_error"
-                android:paddingHorizontal="6dp"
-                android:paddingVertical="4dp"
-                android:visibility="gone"
-                android:layout_marginTop="8dp" />
-        </LinearLayout>
-        
-        <!-- Tile Cycle Card Include -->
-        <include layout="@layout/view_tile_cycle_card" />
-
-        <!-- Developer Profile Card Include -->
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:background="@drawable/section_outline_bg"
-            android:padding="12dp"
-            android:gravity="center_vertical"
-            android:layout_marginTop="0dp">
+        <!-- App Icon -->
+        <FrameLayout
+            android:id="@+id/appIconFrame"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:layout_marginEnd="12dp"
+            android:background="@drawable/shape_app_icon_bg">
             
             <ImageView
-                android:id="@+id/developerPersonIcon"
-                android:layout_width="40dp"
-                android:layout_height="40dp"
-                android:padding="8dp"
-                android:src="@drawable/ic_person"
-                android:tint="@color/brand_primary"
-                android:background="@drawable/social_icon_bg"
-                android:contentDescription="Developer"
-                android:layout_marginEnd="12dp" />
+                android:layout_width="47dp"
+                android:layout_height="47dp"
+                android:layout_gravity="center"
+                android:src="@drawable/ic_launcher_foreground"
+                android:tint="@color/brand_on_primary_container"
+                android:contentDescription="NetToggle" />
+        </FrameLayout>
 
-            <LinearLayout
-                android:layout_width="0dp"
+        <!-- App Title -->
+        <TextView
+            android:id="@+id/appTitleText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_toEndOf="@id/appIconFrame"
+            android:layout_centerVertical="true"
+            android:text="NetToggle"
+            android:textSize="26sp"
+            android:fontFamily="sans-serif-black"
+            android:textColor="@color/text_primary"
+            android:letterSpacing="-0.03" />
+
+        <!-- App Version Badge -->
+        <TextView
+            android:id="@+id/appVersionText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:background="@drawable/shape_pill_badge_bg"
+            android:fontFamily="sans-serif-medium"
+            android:gravity="center"
+            android:minHeight="24dp"
+            android:paddingHorizontal="10dp"
+            android:paddingVertical="3dp"
+            android:text="v0.0.0"
+            android:textColor="@color/brand_on_primary_container"
+            android:textSize="13sp"
+            android:textStyle="bold" />
+    </RelativeLayout>
+
+    <!-- Scrollable Content -->
+		<ScrollView
+			android:layout_width="match_parent"
+			android:layout_height="0dp"
+			android:layout_weight="1"
+			android:fillViewport="true"
+			android:clipToPadding="false"
+			android:paddingBottom="24dp"
+			android:overScrollMode="never">
+	
+			<LinearLayout
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:orientation="vertical"
+				android:paddingHorizontal="16dp"
+				android:paddingTop="16dp"
+				android:paddingBottom="20dp"
+				android:clipToPadding="false"
+				android:gravity="center_horizontal">
+	
+				<!-- Description Text -->
+				<TextView
+					android:layout_width="match_parent"
+					android:layout_height="wrap_content"
+					android:fontFamily="sans-serif"
+					android:lineSpacingExtra="3dp"
+					android:layout_marginBottom="16dp"
+					android:text="Switch between 5G, 4G, 3G, 2G, and Preferred network modes directly from Quick Settings."
+					android:textColor="@color/text_secondary"
+					android:textSize="13sp" />
+	
+				<!-- Quick Settings Tile Hint Card -->
+			<LinearLayout
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:orientation="horizontal"
+				android:background="@drawable/shape_qs_hint_bg"
+				android:padding="12dp"
+				android:gravity="center_vertical"
+				android:layout_marginTop="0dp"
+				android:layout_marginBottom="12dp">
+	
+				<FrameLayout
+					android:layout_width="38dp"
+					android:layout_height="38dp"
+					android:background="@drawable/shape_pill_badge_bg"
+					android:layout_marginEnd="10dp">
+	
+					<ImageView
+						android:layout_width="20dp"
+						android:layout_height="20dp"
+						android:layout_gravity="center"
+						android:src="@drawable/ic_network_bars"
+						android:tint="@color/brand_primary"
+						android:contentDescription="QS Tile" />
+				</FrameLayout>
+	
+				<LinearLayout
+					android:layout_width="0dp"
+					android:layout_height="wrap_content"
+					android:layout_weight="1"
+					android:orientation="vertical">
+	
+					<TextView
+						android:layout_width="wrap_content"
+						android:layout_height="wrap_content"
+						android:text="Quick Settings Ready"
+						android:textSize="13sp"
+						android:fontFamily="sans-serif-medium"
+						android:textStyle="bold"
+						android:textColor="@color/text_primary" />
+	
+					<TextView
+						android:layout_width="wrap_content"
+						android:layout_height="wrap_content"
+						android:text="Add NetToggle tile to your Control Center or Quick Settings"
+						android:textSize="11sp"
+						android:textColor="@color/text_secondary" />
+				</LinearLayout>
+			</LinearLayout>
+	
+            <!-- Execution Mode Card Include -->
+            <include 
+                layout="@layout/view_execution_card"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:orientation="vertical">
+                android:layout_marginBottom="12dp" />
+			
+			<!-- Tile Cycle Card Include -->
+			<include 
+				layout="@layout/view_tile_cycle_card"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:layout_marginBottom="12dp" />
+	
+		</LinearLayout>
+	</ScrollView>
 
-                <TextView
-                    android:id="@+id/developerTitleText"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="DEVELOPER"
-                    android:textSize="10sp"
-                    android:fontFamily="sans-serif-medium"
-                    android:textStyle="bold"
-                    android:letterSpacing="0.08"
-                    android:textColor="@color/text_tertiary" />
+	<!-- Developer Profile Card Include -->
+	<LinearLayout
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:layout_margin="16dp"
+		android:layout_marginBottom="24dp"
+		android:orientation="horizontal"
+		android:background="@drawable/shape_floating_footer"
+		android:paddingHorizontal="20dp"
+		android:paddingVertical="12dp"
+		android:gravity="center_vertical"
+		android:elevation="12dp">
+		
+		<ImageView
+			android:id="@+id/developerPersonIcon"
+			android:layout_width="40dp"
+			android:layout_height="40dp"
+			android:padding="8dp"
+			android:src="@drawable/ic_person"
+			android:tint="@color/accent_pink"
+			android:background="@drawable/social_icon_bg"
+			android:contentDescription="Developer"
+			android:layout_marginEnd="12dp" />
 
-                <TextView
-                    android:id="@+id/developerNameText"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="Dhangofa"
-                    android:textSize="15sp"
-                    android:fontFamily="sans-serif-medium"
-                    android:textStyle="bold"
-                    android:textColor="@color/text_primary" />
-            </LinearLayout>
+		<LinearLayout
+			android:layout_width="0dp"
+			android:layout_height="wrap_content"
+			android:layout_weight="1"
+			android:orientation="vertical">
 
-            <LinearLayout
-                android:id="@+id/socialLinksRow"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
+			<TextView
+				android:id="@+id/developerTitleText"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:text="DEVELOPER"
+				android:textSize="10sp"
+				android:fontFamily="sans-serif-medium"
+				android:textStyle="bold"
+				android:letterSpacing="0.08"
+				android:textColor="@color/text_tertiary" />
 
-                <ImageView
-                    android:id="@+id/githubLink"
-                    android:layout_width="36dp"
-                    android:layout_height="36dp"
-                    android:padding="8dp"
-                    android:src="@drawable/ic_github"
-                    android:tint="@color/text_primary"
-                    android:background="@drawable/social_icon_bg"
-                    android:layout_marginEnd="8dp"
-                    android:clickable="true"
-                    android:focusable="true" />
+			<TextView
+				android:id="@+id/developerNameText"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:text="Dhangofa"
+				android:textSize="15sp"
+				android:fontFamily="sans-serif-medium"
+				android:textStyle="bold"
+				android:textColor="@color/text_primary" />
+		</LinearLayout>
 
-                <ImageView
-                    android:id="@+id/telegramLink"
-                    android:layout_width="36dp"
-                    android:layout_height="36dp"
-                    android:padding="8dp"
-                    android:src="@drawable/ic_telegram"
-                    android:tint="@color/text_primary"
-                    android:background="@drawable/social_icon_bg"
-                    android:clickable="true"
-                    android:focusable="true" />
-            </LinearLayout>
-        </LinearLayout>
-    </LinearLayout>
-</ScrollView>
+		<LinearLayout
+			android:id="@+id/socialLinksRow"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:orientation="horizontal">
+
+			<ImageView
+				android:id="@+id/githubLink"
+				android:layout_width="36dp"
+				android:layout_height="36dp"
+				android:padding="8dp"
+				android:src="@drawable/ic_github"
+				android:tint="@color/text_primary"
+				android:background="@drawable/social_icon_bg"
+				android:layout_marginEnd="8dp"
+				android:clickable="true"
+				android:focusable="true" />
+
+			<ImageView
+				android:id="@+id/telegramLink"
+				android:layout_width="36dp"
+				android:layout_height="36dp"
+				android:padding="8dp"
+				android:src="@drawable/ic_telegram"
+				android:tint="@color/text_primary"
+				android:background="@drawable/social_icon_bg"
+				android:clickable="true"
+				android:focusable="true" />
+		</LinearLayout>
+	</LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/bottom_sheet_permission.xml
+++ b/app/src/main/res/layout/bottom_sheet_permission.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="24dp"
+    android:background="@drawable/shape_dialog_bg">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:layout_marginBottom="16dp">
+
+        <ImageView
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:src="@drawable/ic_speed"
+            android:tint="@color/brand_primary"
+            android:background="@drawable/shape_pill_badge_bg"
+            android:padding="12dp"
+            android:layout_marginEnd="16dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Unlock Maximum Performance"
+            android:textSize="20sp"
+            android:fontFamily="sans-serif-medium"
+            android:textStyle="bold"
+            android:textColor="@color/text_primary" />
+    </LinearLayout>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="NetToggle operates faster if it can directly read your SIM state. Please grant the Phone permission to eliminate system lag and enable instant resolution."
+        android:textSize="14sp"
+        android:lineSpacingExtra="4dp"
+        android:textColor="@color/text_secondary"
+        android:layout_marginBottom="24dp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="end">
+
+        <Button
+            android:id="@+id/btnDismissPermission"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Dismiss"
+            style="?android:attr/borderlessButtonStyle"
+            android:textColor="@color/text_secondary"
+            android:layout_marginEnd="8dp" />
+
+        <Button
+            android:id="@+id/btnGrantPermission"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Grant Permission"
+            android:paddingHorizontal="24dp"
+            android:background="@drawable/shape_button_primary"
+            android:textColor="@color/card_surface" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_diagnostic.xml
+++ b/app/src/main/res/layout/dialog_diagnostic.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="20dp"
+    android:background="@drawable/shape_segmented_container">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Diagnostic Report"
+        android:textSize="18sp"
+        android:fontFamily="sans-serif-medium"
+        android:textStyle="bold"
+        android:textColor="@color/text_primary"
+        android:layout_marginBottom="16dp" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="250dp"
+        android:background="#F5F5F5"
+        android:padding="10dp"
+        android:scrollbars="vertical"
+        android:layout_marginBottom="16dp">
+
+        <HorizontalScrollView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:scrollbars="horizontal">
+
+            <TextView
+                android:id="@+id/diagnosticReportText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:typeface="monospace"
+                android:textSize="12sp"
+                android:textColor="#333333" />
+                
+        </HorizontalScrollView>
+    </ScrollView>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="end">
+
+        <TextView
+            android:id="@+id/btnCloseDiagnostic"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="CLOSE"
+            android:textSize="14sp"
+            android:fontFamily="sans-serif-medium"
+            android:textStyle="bold"
+            android:textColor="@color/text_secondary"
+            android:padding="8dp"
+            android:layout_marginEnd="16dp"
+            android:clickable="true"
+            android:focusable="true" />
+
+        <TextView
+            android:id="@+id/btnCopyDiagnostic"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="COPY REPORT"
+            android:textSize="14sp"
+            android:fontFamily="sans-serif-medium"
+            android:textStyle="bold"
+            android:textColor="@color/brand_primary"
+            android:padding="8dp"
+            android:clickable="true"
+            android:focusable="true" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/view_error_banner.xml
+++ b/app/src/main/res/layout/view_error_banner.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/errorBannerContainer"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:background="@drawable/shape_status_badge_error"
+    android:padding="12dp"
+    android:gravity="center_vertical"
+    android:clickable="true"
+    android:focusable="true">
+
+    <ImageView
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:src="@drawable/ic_warning"
+        android:tint="@color/status_error_text"
+        android:layout_marginEnd="10dp"
+        android:contentDescription="Error Icon" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+        
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Command Failed"
+            android:textSize="14sp"
+            android:fontFamily="sans-serif-medium"
+            android:textStyle="bold"
+            android:textColor="@color/status_error_text" />
+            
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Tap to view diagnostic report"
+            android:textSize="12sp"
+            android:textColor="@color/status_error_text" />
+    </LinearLayout>
+    
+    <ImageView
+        android:layout_width="20dp"
+        android:layout_height="20dp"
+        android:src="@drawable/ic_arrow_right"
+        android:tint="@color/status_error_text" />
+</LinearLayout>

--- a/app/src/main/res/layout/view_execution_card.xml
+++ b/app/src/main/res/layout/view_execution_card.xml
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:background="@drawable/shape_exec_card_bg"
+    android:elevation="8dp"
+    android:padding="12dp">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="10dp">
+        
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+            <ImageView
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:src="@drawable/ic_shield"
+                android:tint="@color/exec_accent"
+                android:layout_marginEnd="6dp" />
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Execution Mode"
+                android:textSize="15sp"
+                android:fontFamily="sans-serif-medium"
+                android:textStyle="bold"
+                android:textColor="@color/text_primary" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/shizukuStatusText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:text="Authorized"
+            android:background="@drawable/shape_status_badge_success"
+            android:textColor="#4ADE80"
+            android:textSize="10sp"
+            android:textStyle="bold"
+            android:paddingHorizontal="8dp"
+            android:paddingVertical="4dp" />
+    </RelativeLayout>
+
+    <!-- Segmented Control for Execution Mode -->
+    <RadioGroup
+        android:id="@+id/modeRadioGroup"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:background="@drawable/shape_segmented_container"
+        android:padding="4dp">
+        
+        <RadioButton
+            android:id="@+id/radioRoot"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Root"
+            android:button="@null"
+            android:gravity="center"
+            android:minHeight="40dp"
+            android:paddingVertical="8dp"
+            android:background="@drawable/selector_segmented_tab_exec"
+            android:textColor="@color/color_segmented_text_exec"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+
+        <View 
+            android:id="@+id/separatorRootShizuku"
+            android:layout_width="1dp" 
+            android:layout_height="match_parent" 
+            android:layout_marginTop="6dp"
+            android:layout_marginBottom="6dp"
+            android:background="@color/segmented_separator" />
+
+        <RadioButton
+            android:id="@+id/radioShizuku"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Shizuku"
+            android:button="@null"
+            android:gravity="center"
+            android:minHeight="40dp"
+            android:paddingVertical="8dp"
+            android:background="@drawable/selector_segmented_tab_exec"
+            android:textColor="@color/color_segmented_text_exec"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+    </RadioGroup>
+
+    <View
+        android:layout_width="32dp"
+        android:layout_height="4dp"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
+        android:background="@drawable/shape_small_divider" />
+
+    <!-- Target SIM Header -->
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="10dp">
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="10dp">
+            <ImageView
+                android:layout_width="18dp"
+                android:layout_height="18dp"
+                android:src="@drawable/ic_smartphone"
+                android:tint="@color/exec_accent"
+                android:layout_marginEnd="8dp" />
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Target SIM"
+                android:textSize="15sp"
+                android:fontFamily="sans-serif-medium"
+                android:textStyle="bold"
+                android:textColor="@color/text_primary" />
+        </LinearLayout>
+        <TextView
+            android:id="@+id/autoSimWarningText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Auto failed"
+            android:textSize="11sp"
+            android:gravity="center"
+            android:textColor="@color/status_error_text"
+            android:background="@drawable/shape_status_badge_error"
+            android:paddingHorizontal="6dp"
+            android:paddingVertical="4dp"
+            android:visibility="gone"
+            android:layout_marginTop="8dp" />
+    </RelativeLayout> 
+
+    <!-- Segmented Control for Target SIM -->
+    <RadioGroup
+        android:id="@+id/targetSimRadioGroup"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:background="@drawable/shape_segmented_container"
+        android:padding="4dp">
+        
+        <RadioButton
+            android:id="@+id/radioSimAuto"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Auto"
+            android:button="@null"
+            android:gravity="center"
+            android:minHeight="40dp"
+            android:paddingVertical="8dp"
+            android:background="@drawable/selector_segmented_tab_exec"
+            android:textColor="@color/color_segmented_text_exec"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+
+        <View 
+            android:id="@+id/separatorAutoSim1"
+            android:layout_width="1dp" 
+            android:layout_height="match_parent" 
+            android:layout_marginTop="6dp"
+            android:layout_marginBottom="6dp"
+            android:background="@color/segmented_separator" />
+
+        <RadioButton
+            android:id="@+id/radioSim1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="SIM 1"
+            android:button="@null"
+            android:gravity="center"
+            android:minHeight="40dp"
+            android:paddingVertical="8dp"
+            android:background="@drawable/selector_segmented_tab_exec"
+            android:textColor="@color/color_segmented_text_exec"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+
+        <View 
+            android:id="@+id/separatorSim1Sim2"
+            android:layout_width="1dp" 
+            android:layout_height="match_parent" 
+            android:layout_marginTop="6dp"
+            android:layout_marginBottom="6dp"
+            android:background="@color/segmented_separator" />
+
+        <RadioButton
+            android:id="@+id/radioSim2"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="SIM 2"
+            android:button="@null"
+            android:gravity="center"
+            android:minHeight="40dp"
+            android:paddingVertical="8dp"
+            android:background="@drawable/selector_segmented_tab_exec"
+            android:textColor="@color/color_segmented_text_exec"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+    </RadioGroup>
+</LinearLayout>

--- a/app/src/main/res/layout/view_execution_card.xml
+++ b/app/src/main/res/layout/view_execution_card.xml
@@ -105,6 +105,7 @@
 
     <!-- Target SIM Header -->
     <RelativeLayout
+        android:id="@+id/targetSimHeaderContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="10dp">

--- a/app/src/main/res/layout/view_tile_cycle_card.xml
+++ b/app/src/main/res/layout/view_tile_cycle_card.xml
@@ -2,8 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginBottom="12dp"
-    android:background="@drawable/section_outline_bg"
+    android:background="@drawable/shape_cycle_card_bg"
+    android:elevation="8dp"
     android:orientation="vertical"
     android:padding="12dp">
 
@@ -20,12 +20,12 @@
             android:orientation="horizontal">
 
             <ImageView
-                android:layout_width="16dp"
-                android:layout_height="16dp"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
                 android:layout_marginEnd="6dp"
                 android:contentDescription="Quick Tile Cycle"
                 android:src="@drawable/ic_refresh"
-                android:tint="@color/brand_primary" />
+                android:tint="@color/accent_orange" />
 
             <TextView
                 android:layout_width="wrap_content"
@@ -33,7 +33,7 @@
                 android:fontFamily="sans-serif-medium"
                 android:text="Quick Tile Cycle"
                 android:textColor="@color/text_primary"
-                android:textSize="13sp"
+                android:textSize="15sp"
                 android:textStyle="bold" />
         </LinearLayout>
 
@@ -42,11 +42,11 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"
-            android:background="@drawable/shape_pill_badge_bg"
+            android:background="@drawable/shape_cycle_order_badge"
             android:paddingHorizontal="8dp"
             android:paddingVertical="4dp"
             android:text="3/3"
-            android:textColor="@color/brand_primary"
+            android:textColor="@color/accent_orange"
             android:textSize="10sp"
             android:textStyle="bold" />
     </RelativeLayout>
@@ -62,40 +62,69 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-        <CheckBox
-            android:id="@+id/cycle5gOnly"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="4dp"
-            android:layout_weight="1"
-            android:background="@drawable/shape_radio_item_bg"
-            android:buttonTint="@color/brand_primary"
-            android:fontFamily="sans-serif-medium"
-            android:minHeight="44dp"
-            android:paddingHorizontal="6dp"
-            android:paddingVertical="8dp"
-            android:text="5G Only"
-            android:textColor="@color/text_primary"
-            android:textSize="12sp"
-            android:textStyle="bold" />
+        android:orientation="horizontal"
+        android:background="@drawable/shape_segmented_container_rect"
+        android:padding="4dp">
 
         <CheckBox
             android:id="@+id/cyclePreferred5g"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginStart="4dp"
             android:layout_weight="1"
-            android:background="@drawable/shape_radio_item_bg"
-            android:buttonTint="@color/brand_primary"
-            android:fontFamily="sans-serif-medium"
-            android:minHeight="44dp"
-            android:paddingHorizontal="6dp"
+            android:background="@drawable/selector_segmented_tab_cycle"
+            android:button="@null"
+            android:gravity="center"
+            android:minHeight="40dp"
             android:paddingVertical="8dp"
-            android:text="Preferred 5G"
-            android:textColor="@color/text_primary"
-            android:textSize="12sp"
+            android:text="Pref 5G"
+            android:textColor="@color/color_segmented_text_cycle"
+            android:textSize="13sp"
+            android:textStyle="bold" />
+
+        <View
+            android:id="@+id/separatorCyclePref1"
+            android:layout_width="1dp"
+            android:layout_height="match_parent"
+            android:layout_marginTop="6dp"
+            android:layout_marginBottom="6dp"
+            android:background="@color/segmented_separator" />
+
+        <CheckBox
+            android:id="@+id/cyclePreferred4g"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="@drawable/selector_segmented_tab_cycle"
+            android:button="@null"
+            android:gravity="center"
+            android:minHeight="40dp"
+            android:paddingVertical="8dp"
+            android:text="Pref 4G"
+            android:textColor="@color/color_segmented_text_cycle"
+            android:textSize="13sp"
+            android:textStyle="bold" />
+
+        <View
+            android:id="@+id/separatorCyclePref2"
+            android:layout_width="1dp"
+            android:layout_height="match_parent"
+            android:layout_marginTop="6dp"
+            android:layout_marginBottom="6dp"
+            android:background="@color/segmented_separator" />
+
+        <CheckBox
+            android:id="@+id/cyclePreferred3g"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="@drawable/selector_segmented_tab_cycle"
+            android:button="@null"
+            android:gravity="center"
+            android:minHeight="40dp"
+            android:paddingVertical="8dp"
+            android:text="Pref 3G"
+            android:textColor="@color/color_segmented_text_cycle"
+            android:textSize="13sp"
             android:textStyle="bold" />
     </LinearLayout>
 
@@ -103,40 +132,69 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:background="@drawable/shape_segmented_container_rect"
+        android:padding="4dp">
+
+        <CheckBox
+            android:id="@+id/cycle5gOnly"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="@drawable/selector_segmented_tab_cycle"
+            android:button="@null"
+            android:gravity="center"
+            android:minHeight="40dp"
+            android:paddingVertical="8dp"
+            android:text="5G Only"
+            android:textColor="@color/color_segmented_text_cycle"
+            android:textSize="13sp"
+            android:textStyle="bold" />
+
+        <View
+            android:id="@+id/separatorCycleOnly1"
+            android:layout_width="1dp"
+            android:layout_height="match_parent"
+            android:layout_marginTop="6dp"
+            android:layout_marginBottom="6dp"
+            android:background="@color/segmented_separator" />
 
         <CheckBox
             android:id="@+id/cycle4gOnly"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="4dp"
             android:layout_weight="1"
-            android:background="@drawable/shape_radio_item_bg"
-            android:buttonTint="@color/brand_primary"
-            android:fontFamily="sans-serif-medium"
-            android:minHeight="44dp"
-            android:paddingHorizontal="6dp"
+            android:background="@drawable/selector_segmented_tab_cycle"
+            android:button="@null"
+            android:gravity="center"
+            android:minHeight="40dp"
             android:paddingVertical="8dp"
             android:text="4G Only"
-            android:textColor="@color/text_primary"
-            android:textSize="12sp"
+            android:textColor="@color/color_segmented_text_cycle"
+            android:textSize="13sp"
             android:textStyle="bold" />
 
+        <View
+            android:id="@+id/separatorCycleOnly2"
+            android:layout_width="1dp"
+            android:layout_height="match_parent"
+            android:layout_marginTop="6dp"
+            android:layout_marginBottom="6dp"
+            android:background="@color/segmented_separator" />
+
         <CheckBox
-            android:id="@+id/cyclePreferred4g"
+            android:id="@+id/cycle2gOnly"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginStart="4dp"
             android:layout_weight="1"
-            android:background="@drawable/shape_radio_item_bg"
-            android:buttonTint="@color/brand_primary"
-            android:fontFamily="sans-serif-medium"
-            android:minHeight="44dp"
-            android:paddingHorizontal="6dp"
+            android:background="@drawable/selector_segmented_tab_cycle"
+            android:button="@null"
+            android:gravity="center"
+            android:minHeight="40dp"
             android:paddingVertical="8dp"
-            android:text="Preferred 4G"
-            android:textColor="@color/text_primary"
-            android:textSize="12sp"
+            android:text="2G Only"
+            android:textColor="@color/color_segmented_text_cycle"
+            android:textSize="13sp"
             android:textStyle="bold" />
     </LinearLayout>
 
@@ -145,12 +203,12 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="12dp"
-        android:background="@drawable/shape_segmented_container"
+        android:background="@drawable/shape_cycle_order_badge"
         android:gravity="center"
-        android:padding="8dp"
+        android:padding="10dp"
         android:text="Cycle: 5G Only → 4G Only → Preferred 5G"
-        android:textColor="@color/text_secondary"
-        android:textSize="10sp"
+        android:textColor="@color/accent_orange"
+        android:textSize="11sp"
         android:textStyle="bold" />
 
 </LinearLayout>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -2,13 +2,13 @@
 <resources>
     <!-- Brand Primary Accents -->
     <color name="brand_primary">#D0BCFF</color>
-    <color name="brand_primary_container">#4F378B</color>
+    <color name="brand_primary_container">#23212A</color>
     <color name="brand_on_primary_container">#EADDFF</color>
 
     <!-- Surfaces & Backgrounds -->
-    <color name="surface_background">#141218</color>
-    <color name="card_surface">#211F26</color>
-    <color name="card_border">#36343B</color>
+    <color name="surface_background">#000000</color>
+    <color name="card_surface">#141218</color>
+    <color name="card_border">#2B2930</color>
     <color name="qs_hint_bg">#2B2930</color>
 
     <!-- Typography -->
@@ -18,7 +18,6 @@
 
     <!-- Status Alerts -->
     <color name="status_success_bg">#1A3822</color>
-    <color name="status_success_text">#A8F2B2</color>
     <color name="status_error_bg">#3E1A19</color>
     <color name="status_error_text">#F2B8B5</color>
 
@@ -26,8 +25,26 @@
     <color name="social_button_bg">#2B2930</color>
 
     <!-- Segmented controls -->
+    <color name="segmented_separator">#49454F</color>
     <color name="segmented_container">#1B1A20</color>
     <color name="segmented_selected">#36323F</color>
     <color name="segmented_text_selected">#EADDFF</color>
     <color name="segmented_text_unselected">#938F96</color>
+
+    <!-- Colorful Accents -->
+    <color name="accent_green">#61D48A</color>
+    <color name="accent_orange">#FFB782</color>
+    <color name="accent_pink">#F48FB1</color>
+
+    <!-- Cycle Card Custom Tones -->
+    <color name="cycle_card_surface">#1A130F</color>
+    <color name="cycle_segmented_selected">#3D210F</color>
+    <color name="cycle_badge_bg">#1B1A20</color>
+    <color name="cycle_segmented_text_selected">#FFB782</color>
+
+    <!-- Exec Card Custom Tones -->
+    <color name="exec_accent">#57AFFF</color>
+    <color name="exec_card_surface">#11161A</color>
+    <color name="exec_segmented_selected">#1A364F</color>
+    <color name="exec_segmented_text_selected">#8ECCFF</color>
 </resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -2,7 +2,7 @@
 <resources>
     <style name="Theme.NetToggle" parent="@android:style/Theme.Material.NoActionBar">
         <item name="android:colorPrimary">@color/brand_primary</item>
-        <item name="android:statusBarColor">@color/surface_background</item>
+        <item name="android:statusBarColor">@color/card_surface</item>
         <item name="android:windowLightStatusBar">false</item>
         <item name="android:navigationBarColor">@color/surface_background</item>
         <item name="android:windowLightNavigationBar">false</item>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,11 +2,11 @@
 <resources>
     <!-- Brand Primary Accents -->
     <color name="brand_primary">#6750A4</color>
-    <color name="brand_primary_container">#EADDFF</color>
+    <color name="brand_primary_container">#F3EDF7</color>
     <color name="brand_on_primary_container">#21005D</color>
 
     <!-- Surfaces & Backgrounds -->
-    <color name="surface_background">#FAF8F5</color>
+    <color name="surface_background">#FDFBFF</color>
     <color name="card_surface">#FFFFFF</color>
     <color name="card_border">#E7E0EC</color>
     <color name="qs_hint_bg">#F3EDF7</color>
@@ -18,7 +18,6 @@
 
     <!-- Status Alerts -->
     <color name="status_success_bg">#E8F5E9</color>
-    <color name="status_success_text">#1E4620</color>
     <color name="status_error_bg">#FFEDEA</color>
     <color name="status_error_text">#8C1D18</color>
     
@@ -26,8 +25,26 @@
     <color name="social_button_bg">#F4EFF4</color>
 
     <!-- Segmented controls -->
+    <color name="segmented_separator">#CAC4D0</color>
     <color name="segmented_container">#F3EDF7</color>
     <color name="segmented_selected">#EADDFF</color>
     <color name="segmented_text_selected">#21005D</color>
     <color name="segmented_text_unselected">#49454F</color>
+
+    <!-- Colorful Accents -->
+    <color name="accent_green">#198754</color>
+    <color name="accent_orange">#D96509</color>
+    <color name="accent_pink">#C2185B</color>
+
+    <!-- Cycle Card Custom Tones -->
+    <color name="cycle_card_surface">#FFF8F3</color>
+    <color name="cycle_segmented_selected">#FFE0C2</color>
+    <color name="cycle_badge_bg">#F3EDF7</color>
+    <color name="cycle_segmented_text_selected">#7A3600</color>
+
+    <!-- Exec Card Custom Tones -->
+    <color name="exec_accent">#005B9F</color>
+    <color name="exec_card_surface">#F2F8FF</color>
+    <color name="exec_segmented_selected">#D6EBFF</color>
+    <color name="exec_segmented_text_selected">#004275</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -7,4 +7,10 @@
         <item name="android:navigationBarColor">@color/surface_background</item>
         <item name="android:windowLightNavigationBar">true</item>
     </style>
+    <style name="TransparentBottomSheetStyle" parent="@android:style/Theme.Dialog">
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:backgroundDimEnabled">true</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,7 +2,7 @@
 <resources>
     <style name="Theme.NetToggle" parent="@android:style/Theme.Material.Light.NoActionBar">
         <item name="android:colorPrimary">@color/brand_primary</item>
-        <item name="android:statusBarColor">@color/surface_background</item>
+        <item name="android:statusBarColor">@color/card_surface</item>
         <item name="android:windowLightStatusBar">true</item>
         <item name="android:navigationBarColor">@color/surface_background</item>
         <item name="android:windowLightNavigationBar">true</item>


### PR DESCRIPTION
This pull request introduces significant architectural improvements to network capability resolution, modernizes the UI with a distinct segmented control design, adds robust diagnostic tracking, and expands the global LTEandAbove carrier registry.

### Major Changes

*   **Robust Network Capability Resolution:** Implemented a 4-stage network capability resolver (`NetworkCapabilityResolver`) that evaluates hardware ceilings and combines them with exact per-slot configuration restrictions. This solves the core "Capability vs Coverage" architecture issue, ensuring the UI accurately reflects available network modes.
*   **LTEandAbove Carrier Registry Expansion:** The `LteAndAboveCarrierRegistry` has been significantly expanded with verified global 2G/3G sunset data for mid-2026. Added registries for the USA (now including AT&T, T-Mobile, Dish), Japan (Docomo, KDDI, SoftBank, Rakuten), Australia (Telstra, Optus, Vodafone), Taiwan, Singapore, and South Korea (LG U+). This ensures 2G/3G options are disabled for carriers that no longer support them.
*   **Diagnostic Tracking and Reporting:** Implemented a comprehensive diagnostic system (`DiagnosticReporter`, `DiagnosticError`). The app now tracks explicit tile failures (Root, Shizuku, Command) and caches the `stderr` output of failing shell commands. A new Diagnostic Dialog allows users to view and copy these error reports for debugging.
*   **Native API Fast-Paths:** 
    *   **Network Mode Reading:** Refactored `NetworkModeReader` to execute a try-catch block calling `Settings.Global.getString` directly via Android's native Settings API before falling back to the slower shell execution.
    *   **SIM Resolution:** Upgraded `SimResolver` to leverage the native `SubscriptionManager` APIs to quickly resolve the target physical SIM slot and sub ID. This requires the newly added `READ_PHONE_STATE` permission, which is requested via a custom bottom sheet on launch. The old `dumpsys isub` shell command is retained purely as a fallback.
*   **UI Modernization & Modularization:**
    *   **Segmented Controls:** Upgraded the "Execution Mode", "Target SIM", and "Quick Tile Cycle" selectors from basic radio buttons to modern, fully rounded pill-shaped segmented controls using custom color-state selectors.
    *   **Modular Layouts:** Extracted the UI blocks into dedicated, reusable component files (`view_execution_card.xml`, `view_tile_cycle_card.xml`) utilizing elevated, rounded backgrounds.
    *   **Landscape Support:** Refactored the landscape layout (`layout-land/activity_main.xml`) to display the new modular cards side-by-side dynamically.
    *   **Tile Cycle Expansion:** Expanded the Quick Tile Cycle options from a 2x2 grid to a 2x3 grid, now supporting "Pref 3G" and "2G Only" modes.

### Improvements & Tweaks

*   **Dynamic UI Filtering:** The Quick Tile Cycle checkboxes now dynamically disable and uncheck specific network modes (like 5G or 2G) if the background capability resolver determines the device or SIM does not support them.
*   **Passive Shizuku Checks:** The Quick Settings tile now performs a passive `Shizuku.pingBinder()` check on `onStartListening()`, dynamically updating the tile's UI state (e.g., "Shizuku Unavailable") if the binder dies.
*   **UI Authorization Dimming:** The app now visually dims (reduces opacity) the Target SIM and Tile Cycle cards when Root or Shizuku is not authorized, preventing interaction until setup is complete.
*   **Color Palette Overhaul:** Modernized the light and dark mode color palettes. Introduced distinct warm/orange custom tones for the Quick Tile Cycle card and cool/blue custom tones for the Execution Mode card to provide strong visual hierarchy.
*   **Status Bar Blending:** Changed the status bar color from the background color to the card surface color, creating a seamless, edge-to-edge aesthetic with the new top Action Bar layout.
*   **Shell Parser Upgrades:** Updated `ShellValueParser` to safely extract integers following specific keywords (crucial for catching `-1` invalid indices) and added support for extracting string values (like carrier names).
*   **Universal Legacy Network Mapping:** Updated the binary masks for PREFERRED_4G (Mode 22) and PREFERRED_3G (Mode 21) to ensure total worldwide compatibility and proper fallback for Chinese regional networks (TD-SCDMA).